### PR TITLE
Update Task to accept any Reissue::Task config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.5] - Unreleased
 
+### Changed
+
+- Allow all Reissue::Task methods to be set as attributes.
+
 ## [0.2.4] - 2024-11-01
 
 ### Added

--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -38,13 +38,11 @@ module Discharger
     attr_accessor :pull_request_url
 
     # Reissue settings
-    attr_accessor :version_file
-    attr_accessor :version_limit
-    attr_accessor :version_redo_proc
-    attr_accessor :changelog_file
-    attr_accessor :updated_paths
-    attr_accessor :commit
-    attr_accessor :commit_finalize
+    attr_accessor(
+      *Reissue::Task.instance_methods(false).reject { |method|
+        method.to_s.match?(/[\?=]\z/) || method_defined?(method)
+      }
+    )
 
     def initialize(name = :release, tasker: Rake::Task)
       @name = name


### PR DESCRIPTION
Reissue version 0.3.3 allows old changelog entries to be retained in a separate directory.

This changes Discharger to allow for the configuration to pass through the release task config.