### PR TITLE
Add threaded Changelog to release message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Reset the production branch to the staging branch instead of rebasing.
+- Deploy slack message now threads the changelog for the release.


### PR DESCRIPTION
The deploy slack message now threads the changelog for the release

<img width="402" alt="Screenshot 2025-02-05 at 1 12 31 PM" src="https://github.com/user-attachments/assets/b4baa0ca-eb47-4414-ab22-9ff8fc365fdb" />
