### PR TITLE
Fix incorrect new version branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.10] - Unreleased
 
+### Fixed
+
+- Fixed the incorrectly named new version branch.
+
 ## [0.2.9] - 2025-03-03
 
 ### Fixed

--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -164,13 +164,9 @@ module Discharger
           Preparing to bump the version for the next release.
 
         MSG
-
         tasker["reissue"].invoke
-        new_version = Object.const_get(version_constant)
-        new_version_branch = "bump/begin-#{new_version.tr(".", "-")}"
-        continue = syscall(["git checkout -b #{new_version_branch}"])
 
-        abort "Bump failed." unless continue
+        new_version_branch = `git rev-parse --abbrev-ref HEAD`.strip
 
         pr_url = "#{pull_request_url}/compare/#{working_branch}...#{new_version_branch}?expand=1&title=Begin%20#{current_version}"
 


### PR DESCRIPTION
This relies on the behavior of reissue to use the branch it creates for the new version.
Reissue will create a reissue/new.version.number branch so Discharger doesn't need to create its own.