### PR TITLE
Overcome github frozen bundle errors

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -58,6 +58,11 @@ jobs:
           git checkout -b $branch_name
           echo "branch_name=$branch_name" >> $GITHUB_ENV
       
+      - name: Disable bundler deployment mode
+        run: |
+          bundle config unset deployment
+          bundle config unset frozen
+
       - name: Run reissue task
         run: |
           bundle exec rake reissue[${{ steps.version.outputs.version }}]


### PR DESCRIPTION
The error from the prepare release workflow was:

  The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set