### PR TITLE
Ignore vendor to avoid problems after bundling

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,11 +33,6 @@ jobs:
         run: |
           current_version=$(ruby -r ./lib/discharger/version.rb -e 'puts Discharger::VERSION')
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
-      
-      - name: Disable bundler deployment mode
-        run: |
-          bundle config unset deployment
-          bundle config unset frozen
 
       - name: Prepare release with Reissue
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/vendor/
 /doc/
 /log/*.log
 /pkg/


### PR DESCRIPTION
`rake reissue` runs `bundle` which was loading dependencies into `/vendor`
