### PR TITLE
Fix release workflows to work with Reissue gem

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,18 +28,20 @@ jobs:
           bundler-cache: true
           ruby-version: ruby
       
+      - name: Configure Bundler
+        run: |
+          bundle config set frozen false
+
       - name: Get current version
         id: current_version
         run: |
           current_version=$(ruby -r ./lib/discharger/version.rb -e 'puts Discharger::VERSION')
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
 
-      - name: Prepare release with Reissue
+      - name: Build and finalize release
         run: |
-          bundle exec rake reissue
-      
-      - name: Build gem
-        run: |
+          # The build:checksum task will automatically run reissue:finalize first
+          # This will update the changelog and then build the gem with checksum
           bundle exec rake build:checksum
       
       - name: Create Pull Request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,54 @@ jobs:
           bundler-cache: true
           ruby-version: ruby
 
-      # Build and Release
-      - name: Build gem with checksum
-        run: bundle exec rake build:checksum
+      # Configure bundler for modifications
+      - name: Configure Bundler
+        run: |
+          bundle config set frozen false
 
-      - name: Release gem
-        run: bundle exec rake release
+      # Release gem (will automatically bump version via reissue)
+      - name: Release gem to RubyGems
+        run: |
+          # The release task will:
+          # 1. Push gem to RubyGems
+          # 2. Automatically run rake reissue (with default patch segment)
+          # Since GITHUB_ACTIONS is set, reissue won't commit
+          bundle exec rake release
         env:
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+
+      # Get the new version
+      - name: Get new version
+        id: new_version
+        run: |
+          new_version=$(ruby -r ./lib/discharger/version.rb -e 'puts Discharger::VERSION')
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+      # Create PR for next version
+      - name: Create Pull Request for next version
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bump-version-${{ steps.new_version.outputs.new_version }}
+          base: main
+          commit-message: "Bump version to ${{ steps.new_version.outputs.new_version }}"
+          title: "Bump version to ${{ steps.new_version.outputs.new_version }}"
+          body: |
+            ## 🔄 Post-Release Version Bump
+
+            This PR prepares the codebase for development of version ${{ steps.new_version.outputs.new_version }}.
+
+            ### Changes Made
+            - ✅ Version bumped to ${{ steps.new_version.outputs.new_version }}
+            - ✅ CHANGELOG.md prepared with new Unreleased section
+            - ✅ Gemfile.lock updated with new version
+            - ✅ All dependencies resolved via bundle install
+
+            ### Next Steps
+            1. Review the version bump
+            2. Merge this PR to continue development
+
+            All future commits will be tracked under version ${{ steps.new_version.outputs.new_version }}.
+          labels: |
+            dependencies
+            automated

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,8 @@ require "reissue/gem"
 
 Reissue::Task.create :reissue do |task|
   task.version_file = "lib/discharger/version.rb"
-  task.commit = true
+  task.commit = !ENV["GITHUB_ACTIONS"]
+  task.commit_finalize = !ENV["GITHUB_ACTIONS"]
   task.push_finalize = :branch
 end
 


### PR DESCRIPTION
This commit fixes the GitHub Actions workflows to properly integrate with
the Reissue gem for automated release management.

Changes to prepare-release.yml:
- Added 'bundle config set frozen false' to allow file modifications
- Simplified to just run 'rake build:checksum' which automatically runs
  'reissue:finalize' first due to Reissue's task enhancement
- Removed manual git operations since Reissue handles file updates

Changes to release.yml:
- Added 'bundle config set frozen false' for consistency
- Enhanced the release workflow to create a PR for version bump after
  releasing to RubyGems
- The 'rake release' task automatically calls 'rake reissue' to bump
  the version (Reissue gem enhancement)
- Added step to capture the new version number for PR creation
- Creates a PR with the bumped version, updated CHANGELOG, and
  updated Gemfile.lock

Changes to Rakefile:
- Modified Reissue configuration to disable git commits when running
  in GitHub Actions (ENV['GITHUB_ACTIONS'] is set)
- This allows the create-pull-request action to handle all git
  operations while Reissue still performs all file modifications

The workflow now follows this pattern:
1. Manually trigger prepare-release to finalize changelog
2. Review and merge the release PR with 'approved-release' label
3. Release workflow automatically publishes gem and creates version bump PR
4. Review and merge the version bump PR to continue development

This approach minimizes custom logic in the workflows and relies on
Reissue's built-in functionality for version and changelog management.