### PR TITLE
Release v0.2.13

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -41,8 +41,9 @@ jobs:
 
       - name: Build and finalize release
         run: |
-          # The build:checksum task will automatically run reissue:finalize first
-          # This will update the changelog and then build the gem with checksum
+          # First ensure the release is finalized in changelog
+          bundle exec rake reissue:finalize
+          # Then build the gem with checksum
           bundle exec rake build:checksum
       
       - name: Create Pull Request


### PR DESCRIPTION
## 🚀 Release v0.2.13

This PR finalizes the release for version 0.2.13.

### Changes Made  
- ✅ CHANGELOG.md already finalized with release date (2025-09-02)
- ✅ Version 0.2.13 ready for release
- ✅ Added fragment cleanup functionality  
- ✅ Fixed prepare-release workflow to explicitly run reissue:finalize

### Next Steps
1. This PR already has the `approved-release` label
2. Merge this PR when ready
3. The release workflow will automatically publish to RubyGems.org

⚠️ **Ready to release v0.2.13!**