### PR TITLE
Add debugging for Trusted Publishing OIDC claims

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,20 @@ jobs:
         run: |
           bundle config set frozen false
 
+      # Debug OIDC token
+      - name: Debug OIDC Claims
+        run: |
+          echo "Repository: $GITHUB_REPOSITORY"
+          echo "Workflow: $GITHUB_WORKFLOW"
+          echo "Job: $GITHUB_JOB"
+          echo "Ref: $GITHUB_REF"
+          echo "Actor: $GITHUB_ACTOR"
+
       # Configure Trusted Publishing
       - name: Configure Trusted Publishing
         uses: rubygems/configure-rubygems-credentials@main
+        with:
+          gem-server: https://rubygems.org
 
       # Release gem (will automatically bump version via reissue)
       - name: Release gem to RubyGems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed version on GitHub trusted publisher action.
+- Fixed version on GitHub trusted publisher action.\
+- Added debugging for OIDC.
 
 ## [0.2.12] - 2025-08-19
 


### PR DESCRIPTION
- Add gem-server parameter to explicitly specify rubygems.org
- Add debug step to show OIDC token claims for troubleshooting
- This will help identify why trusted publisher lookup is failing