### PR TITLE
Add commit step for finalization changes before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,17 @@ jobs:
           current_version=$(ruby -r ./lib/discharger/version.rb -e 'puts Discharger::VERSION')
           echo "current_version=$current_version" >> $GITHUB_OUTPUT
 
+      # Commit finalization changes if any exist
+      - name: Commit finalization changes if needed
+        run: |
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Finalize version ${{ steps.current_version.outputs.current_version }} for release"
+            echo "Changes committed for finalization"
+          else
+            echo "No changes to commit - changelog already finalized"
+          fi
+
       # Release gem using official RubyGems action
       - name: Release gem to RubyGems
         uses: rubygems/release-gem@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added clean up fragment_directory task on Task.
 - Added trusted publisher flow to GitHub release action.
+- Adding commit step if needed after the finalize.
 
 ### Fixed
 


### PR DESCRIPTION
This ensures the working directory is clean when rake release runs its guard_clean check, preventing the 'files need to be committed first' error.
