### PR TITLE
Adding in version_limit fix

### DIFF
--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -170,7 +170,8 @@ module Discharger
 
         MSG
         tasker["reissue"].invoke
-
+        
+        tasker["reissue:reformat"].invoke
         new_version_branch = `git rev-parse --abbrev-ref HEAD`.strip
 
         pr_url = "#{pull_request_url}/compare/#{working_branch}...#{new_version_branch}?expand=1&title=Begin%20#{current_version}"


### PR DESCRIPTION
The version_limit value wasn't being used for the the final step to clean up a changelog limit that was passing in a limit = 1. This should clean up the release task. Making sure that on task it invokes `reformat` to prune the changelog.