### PR TITLE
Updating Reissue version, and Rake

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,12 +209,12 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.0)
+    rake (13.3.1)
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
     regexp_parser (2.11.3)
-    reissue (0.4.4)
+    reissue (0.4.5)
       rake
     reline (0.6.2)
       io-console (~> 0.5)
@@ -295,4 +295,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.6.3
+   2.6.8


### PR DESCRIPTION
Updating to use latest Reissue to help out with git tag regex issue with letter at the end of the tag.