### PR TITLE
Use shared release workflow from reissue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,106 +3,20 @@ name: Release gem to RubyGems.org
 on:
   workflow_dispatch:
     inputs:
-      version_segment:
-        description: 'Version segment to bump (patch, minor, major)'
+      dry_run:
+        description: 'Test workflow without publishing to RubyGems'
         required: false
-        default: 'patch'
-        type: choice
-        options:
-        - patch
-        - minor
-        - major
+        type: boolean
+        default: false
 
 jobs:
   release:
-    name: Release gem to RubyGems.org
-    runs-on: ubuntu-latest
-
+    uses: SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main
+    with:
+      git_user_email: 'gems@sofwarellc.com'
+      git_user_name: 'SOFware'
+      dry_run: ${{ inputs.dry_run }}
     permissions:
-      id-token: write  # Required for Trusted Publishing
+      id-token: write
       contents: write
       pull-requests: write
-      issues: write
-
-    steps:
-      # Set up
-      - name: Setup Git
-        run: |
-          git config --global user.email "gems@sofwarellc.com"
-          git config --global user.name "SOFware"
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-          fetch-depth: 0
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: ruby
-
-      # Configure bundler for modifications
-      - name: Configure Bundler
-        run: |
-          bundle config set frozen false
-
-      # Finalize changelog and build gem with checksum
-      - name: Finalize and build gem with checksum
-        run: bundle exec rake build:checksum
-
-      # Get current version before release
-      - name: Get current version
-        id: current_version
-        run: |
-          current_version=$(ruby -r ./lib/discharger/version.rb -e 'puts Discharger::VERSION')
-          echo "current_version=$current_version" >> $GITHUB_OUTPUT
-
-      # Commit finalization changes if any exist
-      - name: Commit finalization changes if needed
-        run: |
-          git add -A
-          if ! git diff --cached --quiet; then
-            git commit -m "Finalize version ${{ steps.current_version.outputs.current_version }} for release"
-            echo "Changes committed for finalization"
-          else
-            echo "No changes to commit - changelog already finalized"
-          fi
-
-      # Release gem using official RubyGems action
-      - name: Release gem to RubyGems
-        uses: rubygems/release-gem@v1
-
-      # Get the new version after automatic bump
-      - name: Get new version
-        id: new_version
-        run: |
-          new_version=$(ruby -r ./lib/discharger/version.rb -e 'puts Discharger::VERSION')
-          echo "new_version=$new_version" >> $GITHUB_OUTPUT
-
-      # Create PR for next version
-      - name: Create Pull Request for next version
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: bump-version-${{ steps.new_version.outputs.new_version }}
-          base: main
-          commit-message: "Bump version to ${{ steps.new_version.outputs.new_version }}"
-          title: "Bump version to ${{ steps.new_version.outputs.new_version }}"
-          body: |
-            ## 🔄 Post-Release Version Bump
-
-            This PR prepares the codebase for development of version ${{ steps.new_version.outputs.new_version }}.
-
-            ### Changes Made
-            - ✅ Version bumped to ${{ steps.new_version.outputs.new_version }}
-            - ✅ CHANGELOG.md prepared with new Unreleased section
-            - ✅ Gemfile.lock updated with new version
-            - ✅ All dependencies resolved via bundle install
-
-            ### Next Steps
-            1. Review the version bump
-            2. Merge this PR to continue development
-
-            All future commits will be tracked under version ${{ steps.new_version.outputs.new_version }}.
-          labels: |
-            dependencies
-            automated


### PR DESCRIPTION
## Summary

- Replace inline release workflow with call to reissue shared workflow
- Reduces workflow from ~90 lines to ~10 lines
- Adds dry_run option for testing releases without publishing

## Business Justification

Centralizing release logic in the reissue gem reduces maintenance burden across repositories. Bug fixes and improvements to the release process only need to be made once in reissue rather than updated in each consuming gem.

## Technical Details

Uses shared workflow at `SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml`