### PR TITLE
Switch to git trailer fragments for changelog entries

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,8 +7,8 @@ require "reissue/gem"
 
 Reissue::Task.create :reissue do |task|
   task.version_file = "lib/discharger/version.rb"
+  task.fragment = :git
   task.push_finalize = :branch
-  task.clear_fragments = true
 end
 
 Rake::TestTask.new(:test) do |t|


### PR DESCRIPTION
## Summary

- Configure Reissue to use git trailers (`fragment = :git`) instead of file-based changelog fragments
- Remove `clear_fragments` setting (not applicable to git trailers)

## Business Justification

Keeps changelog data coupled with code changes in the same commit, making history self-documenting. Reduces friction by eliminating the need to create separate fragment files for each change.

## Technical Details

Git trailer format for future commits:
```
Changed: Description of what changed
Version: patch
```

The `reissue:preview` task confirms trailers are being detected correctly.