### PR TITLE
Pin Ruby version to 3.4 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: ruby
+          ruby-version: '3.4'
 
       # Configure bundler for modifications
       - name: Configure Bundler


### PR DESCRIPTION
## Problem

The release workflow started failing after Ruby 4.0.0 was released because `ruby-version: ruby` uses the latest stable Ruby version.

The `faraday-mashify` gem (a dependency of `slack-ruby-client`) requires Ruby `< 4, >= 2.7`, causing this error:

```
faraday-mashify-1.0.0 requires ruby version < 4, >= 2.7, which is incompatible
with the current version, 4.0.0
```

## Solution

This PR pins the Ruby version to `3.4` in the release workflow, matching what's already used in the CI workflow.

## Changes

- Updated `.github/workflows/release.yml` to use `ruby-version: '3.4'` instead of `ruby-version: ruby`

## Testing

- CI workflow already uses Ruby 3.4 and passes
- This change aligns the release workflow with CI

Fixes release workflow run: https://github.com/SOFware/discharger/actions/runs/20795806770