### PR TITLE
Fix URL escaping in open commands and simplify PR URLs

### DIFF
--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -198,8 +198,9 @@ module Discharger
         tasker["reissue"].invoke
 
         new_version_branch = `git rev-parse --abbrev-ref HEAD`.strip
-
-        pr_url = "#{pull_request_url}/compare/#{working_branch}...#{new_version_branch}?expand=1&title=Begin%20#{current_version}"
+        new_version = new_version_branch.split("/").last
+        params = {expand: 1, title: "Bump version to #{new_version}"}
+        pr_url = "#{pull_request_url}/compare/#{working_branch}...#{new_version_branch}?#{params.to_query}"
 
         syscall(["git push origin #{new_version_branch} --force"]) do
           sysecho <<~MSG
@@ -211,7 +212,7 @@ module Discharger
             Opening PR: #{pr_url}
           MSG
         end.then do |success|
-          syscall ["open #{pr_url}"] if success
+          syscall ["open", pr_url] if success
         end
       end
 
@@ -342,7 +343,7 @@ module Discharger
 
           params = {
             expand: 1,
-            title: "Release #{current_version} to production",
+            title: "Stage to Main",
             body: <<~BODY
               Deploy #{current_version} to production.
             BODY
@@ -358,7 +359,7 @@ module Discharger
 
             Once the PR is **approved**, run 'rake release' to release the version.
           MSG
-          syscall ["open #{pr_url}"]
+          syscall ["open", pr_url]
         end
       end
     end


### PR DESCRIPTION
## Summary

- Fix shell URL escaping bug in `open` commands
- Update PR titles to match established conventions

## Root Cause

When `Open3.capture3` receives a single-string command like `["open #{pr_url}"]`, the shell interprets `&` in the URL as a command separator. This truncates URLs at the first `&`, causing title and body parameters to be lost.

**Before (buggy):**
```ruby
syscall ["open #{pr_url}"]  # Shell interprets & as command separator
```

**After (fixed):**
```ruby
syscall ["open", pr_url]    # URL passed as argument, properly escaped
```

## Title Changes

| Step | Before | After |
|------|--------|-------|
| `release:prepare` | "Finish version X" | (unchanged) |
| `release:stage` | "Release X to production" | "Stage to Main" |
| `release` | "Begin X" | "Bump version to X" |

For the `release` step, the new version is extracted from the branch name (reissue creates `reissue/X.Y.Z`).