### PR TITLE
Remove CI-specific commit settings from Reissue task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,8 +7,6 @@ require "reissue/gem"
 
 Reissue::Task.create :reissue do |task|
   task.version_file = "lib/discharger/version.rb"
-  task.commit = !ENV["GITHUB_ACTIONS"]
-  task.commit_finalize = !ENV["GITHUB_ACTIONS"]
   task.push_finalize = :branch
   task.clear_fragments = true
 end


### PR DESCRIPTION
## Summary
- Remove `commit` and `commit_finalize` overrides that disabled commits in GitHub Actions
- Allows Reissue to use default commit behavior, matching reissue's own configuration

## Business Justification
The shared release workflow expects Reissue to commit finalization changes before `rake release` runs. The previous CI-specific settings caused `rake release:guard_clean` to fail because the working directory had uncommitted changes.

## Technical Details
The settings `commit = !ENV["GITHUB_ACTIONS"]` and `commit_finalize = !ENV["GITHUB_ACTIONS"]` were disabling automatic commits during CI runs. By removing these, Reissue now commits finalization changes automatically, ensuring a clean working directory for Bundler's release task.