### PR TITLE
Fix Redis container created when not configured

### DIFF
--- a/lib/discharger/setup_runner/configuration.rb
+++ b/lib/discharger/setup_runner/configuration.rb
@@ -10,7 +10,7 @@ module Discharger
       def initialize
         @app_name = "Application"
         @database = DatabaseConfig.new
-        @redis = RedisConfig.new
+        @redis = nil
         @services = []
         @steps = []
         @custom_steps = []
@@ -25,7 +25,7 @@ module Discharger
 
         config.app_name = yaml["app_name"] if yaml["app_name"]
         config.database.from_hash(yaml["database"]) if yaml["database"]
-        config.redis.from_hash(yaml["redis"]) if yaml["redis"]
+        config.redis = RedisConfig.new.tap { |r| r.from_hash(yaml["redis"]) } if yaml["redis"]
         config.services = yaml["services"] || []
         config.steps = yaml["steps"] || []
         config.custom_steps = yaml["custom_steps"] || []

--- a/test/setup_runner/configuration_test.rb
+++ b/test/setup_runner/configuration_test.rb
@@ -10,7 +10,7 @@ class ConfigurationTest < ActiveSupport::TestCase
 
     assert_equal "Application", config.app_name
     assert_instance_of Discharger::SetupRunner::DatabaseConfig, config.database
-    assert_instance_of Discharger::SetupRunner::RedisConfig, config.redis
+    assert_nil config.redis
     assert_equal [], config.services
     assert_equal [], config.steps
     assert_equal [], config.custom_steps
@@ -72,7 +72,8 @@ class ConfigurationTest < ActiveSupport::TestCase
     # Check defaults are preserved
     assert_equal "db-app", config.database.name
     assert_equal "14", config.database.version
-    assert_equal 6379, config.redis.port
+    # Redis not configured in YAML, so should be nil
+    assert_nil config.redis
   end
 
   test "handles empty YAML file" do
@@ -83,7 +84,8 @@ class ConfigurationTest < ActiveSupport::TestCase
     # Should use all defaults
     assert_equal "Application", config.app_name
     assert_equal 5432, config.database.port
-    assert_equal 6379, config.redis.port
+    # Redis not configured, so should be nil
+    assert_nil config.redis
   end
 
   test "raises error for non-existent file" do


### PR DESCRIPTION
## Summary
- Fix Redis container being created even when `redis:` section is commented out or missing from `setup.yml`
- Initialize `@redis = nil` instead of `RedisConfig.new` so `config.redis` is falsy when not configured

## Problem
When setting up skedify (which has redis commented out in setup.yml), discharger was still trying to create a `redis-app` container on port 6379. This caused:
- Unwanted containers for apps that don't need Redis in development
- Port conflicts when setting up multiple apps (e.g., qualify's `redis-qualify` already on 6379)

## Root cause
`Configuration#initialize` was setting `@redis = RedisConfig.new` by default, making the check `if config.redis` in `docker_command.rb` always pass.