### PR TITLE
Fix PgToolsCommand to use correct config accessor

### DIFF
--- a/lib/discharger/setup_runner/commands/pg_tools_command.rb
+++ b/lib/discharger/setup_runner/commands/pg_tools_command.rb
@@ -13,7 +13,7 @@ module Discharger
         end
 
         def can_execute?
-          config.respond_to?(:db_config) && config.db_config&.name.present?
+          config.respond_to?(:database) && config.database&.name.present?
         end
 
         def execute
@@ -25,7 +25,7 @@ module Discharger
         private
 
         def container_name
-          config.db_config.name
+          config.database.name
         end
 
         def create_pg_tools_directory


### PR DESCRIPTION
## Summary

Fix `PgToolsCommand` to reference `config.database` instead of `config.db_config`.

## Problem

The pg_tools step was always skipped with:
```
⏭️  Skipping Setting up PostgreSQL tools wrappers (prerequisites not met)
```

## Root Cause

- `c41d4ae` (Dec 17): Renamed `db_config` → `database` across Configuration class
- `5560bd7` (Dec 19): Added PgToolsCommand using correct `config.database`
- `6a2d369` (Dec 19): Incorrectly "fixed" to `db_config` based on outdated assumption

This restores the original correct behavior. No other code references `db_config`.