### PR TITLE
Forward tag_pattern to Reissue

### DIFF
--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -23,6 +23,7 @@ module Discharger
         end
         reissue.fragment = task.fragment
         reissue.clear_fragments = task.clear_fragments
+        reissue.tag_pattern = task.tag_pattern
       end
       task.define
       task


### PR DESCRIPTION
## Summary
- Forward `tag_pattern` configuration from `Discharger::Task` to `Reissue::Task` during `create`

## Business Justification
Reissue 0.4.10 replaced the permissive `git for-each-ref` glob with a configurable `tag_pattern` regex (reissue#86), but Discharger never forwarded the setting. Projects using non-semver tag schemes (e.g. `v2026.1.D`) silently fell back to scanning all commits, producing bloated changelogs with entries from the entire repository history.

## Technical Details
The `tag_pattern` accessor was already available on `Discharger::Task` via the dynamic `attr_accessor` block that mirrors `Reissue::Task` methods. However, `self.create` only forwarded an explicit list of attributes and `tag_pattern` was missing. This adds the single forwarding line alongside the other Reissue settings.

## Test plan
- [x] Added test verifying `tag_pattern` is forwarded to the `Reissue::Task` instance
- [x] All existing tests pass