### PR TITLE
Merge release to production via PR instead of direct push

### DIFF
--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -179,6 +179,20 @@ module Discharger
       stdout.strip
     end
 
+    def existing_pr_number(base, head)
+      stdout, _, status = Open3.capture3(
+        "gh", "pr", "list",
+        "--base", base,
+        "--head", head,
+        "--state", "open",
+        "--json", "number",
+        "--jq", ".[0].number // empty"
+      )
+      return nil unless status.success?
+      pr = stdout.strip
+      pr.empty? ? nil : pr
+    end
+
     def define
       require "slack-ruby-client"
       Slack.configure do |config|
@@ -189,14 +203,17 @@ module Discharger
         ---------- STEP 3 ----------
         Release the current version to production
 
-        This task rebases the production branch on the staging branch and tags the
-        current version. The production branch and the tag will be pushed to the
-        remote repository.
+        This task merges the release branch into production via a GitHub pull
+        request and tags the current version.
 
         After the release is complete, a new branch will be created to bump the
         version for the next release.
       DESC
       task "#{name}": [:environment] do
+        unless system("gh --version > /dev/null 2>&1")
+          abort "Error: GitHub CLI (gh) is required for the release process but was not found. Install it: https://cli.github.com"
+        end
+
         current_version = Object.const_get(version_constant)
 
         # When auto_deploy_staging is enabled, release directly from working_branch
@@ -213,27 +230,45 @@ module Discharger
         input = $stdin.gets
         exit if input.chomp.match?(/^x/i)
 
-        # Fetch first, then validate what we fetched
         syscall(
           ["git checkout #{working_branch}"],
           ["git branch -D #{staging_branch} 2>/dev/null || true"],
-          ["git branch -D #{production_branch} 2>/dev/null || true"],
-          ["git fetch origin #{release_source}:#{release_source} #{production_branch}:#{production_branch}"]
+          ["git branch -D #{production_branch} 2>/dev/null || true"]
         )
 
         if auto_deploy_staging
-          # Ensure HEAD is the release commit (the commit that touched the version file)
+          syscall(
+            ["git fetch origin #{production_branch}:#{production_branch} #{working_branch}"],
+            ["git reset --hard origin/#{working_branch}"]
+          )
           validate_release_commit!(release_source)
         else
-          # Standard mode: validate staging branch has same VERSION as working branch
+          syscall(
+            ["git fetch origin #{release_source}:#{release_source} #{production_branch}:#{production_branch}"]
+          )
           validate_version_match!(staging_branch, working_branch)
         end
 
+        pr_ref = release_source
+        if auto_deploy_staging
+          pr_number = existing_pr_number(production_branch, release_source)
+          if pr_number
+            sysecho "Reusing existing PR ##{pr_number} from #{release_source} to #{production_branch}."
+            pr_ref = pr_number
+          else
+            syscall(
+              ["gh pr create --base #{production_branch} --head #{release_source} --title 'Release #{current_version}' --body 'Deploy #{current_version} to production.'"]
+            )
+          end
+        end
+
+        syscall(
+          ["gh pr merge #{pr_ref} --merge"]
+        )
+
         continue = syscall(
-          ["git checkout #{production_branch}"],
-          ["git reset --hard #{release_source}"],
-          ["git tag -a v#{current_version} -m 'Release #{current_version}'"],
-          ["git push origin #{production_branch}:#{production_branch} v#{current_version}:v#{current_version}"],
+          ["git fetch origin #{production_branch}:#{production_branch}"],
+          ["git tag -a v#{current_version} -m 'Release #{current_version}' #{production_branch}"],
           ["git push origin v#{current_version}"]
         ) do
           tasker["#{name}:slack"].invoke("Released #{app_name} #{current_version} (#{commit_identifier.call}) to production.", release_message_channel, ":chipmunk:")
@@ -242,7 +277,8 @@ module Discharger
             tasker["#{name}:slack"].reenable
             tasker["#{name}:slack"].invoke(text, release_message_channel, ":log:", last_message_ts)
           end
-          syscall ["git checkout #{working_branch}"]
+          # Signal success — no branch switch needed since we stay on working_branch throughout
+          true
         end
 
         abort "Release failed." unless continue

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -158,3 +158,160 @@ class DischargerTaskTest < Minitest::Test
     assert_equal true, @task.auto_deploy_staging
   end
 end
+
+class DischargerReleaseCommandSequenceTest < Minitest::Test
+  FAKE_VERSION = "1.2.3"
+
+  def setup
+    @commands = []
+    @original_stdin = $stdin
+    Rake::Task.define_task(:environment) {} unless Rake::Task.task_defined?(:environment)
+  end
+
+  def teardown
+    $stdin = @original_stdin
+  end
+
+  def build_task(name, auto_deploy:)
+    noop_task = Object.new
+    noop_task.define_singleton_method(:invoke) { |*_args| }
+    noop_task.define_singleton_method(:reenable) {}
+    mock_tasker = Object.new
+    mock_tasker.define_singleton_method(:[]) { |_name| noop_task }
+
+    task = Discharger::Task.new(name, tasker: mock_tasker)
+    task.version_constant = "DischargerReleaseCommandSequenceTest::FAKE_VERSION"
+    task.version_file = "VERSION"
+    task.changelog_file = "CHANGELOG.md"
+    task.release_message_channel = "#releases"
+    task.chat_token = "fake_token"
+    task.pull_request_url = "http://example.com"
+    task.app_name = "TestApp"
+    task.commit_identifier = -> { "abc123" }
+    task.auto_deploy_staging = auto_deploy
+
+    commands = @commands
+    task.define_singleton_method(:syscall) do |*steps, **_kwargs, &_block|
+      steps.each { |cmd| commands << cmd }
+      true
+    end
+    task.define_singleton_method(:sysecho) { |*_args, **_kwargs| true }
+    task.define_singleton_method(:validate_version_match!) { |*_args, **_kwargs| true }
+    task.define_singleton_method(:validate_release_commit!) { |*_args, **_kwargs| true }
+    task.define_singleton_method(:existing_pr_number) { |*_args| nil }
+
+    task
+  end
+
+  def command_issued?(pattern)
+    @commands.any? { |cmd|
+      joined = cmd.join(" ")
+      pattern.is_a?(Regexp) ? joined.match?(pattern) : joined == pattern
+    }
+  end
+
+  def test_standard_mode_merges_staging_without_pr_create
+    task = build_task(:rel_std_seq, auto_deploy: false)
+    task.define
+    $stdin = StringIO.new("\n")
+
+    capture_io { Rake::Task["rel_std_seq"].invoke }
+
+    refute command_issued?(/gh pr create/),
+      "Standard mode should not create a PR"
+    assert command_issued?("gh pr merge stage --merge"),
+      "Should merge staging branch"
+    assert command_issued?(/git tag -a v1\.2\.3 .+ main/),
+      "Should tag production branch"
+    assert command_issued?("git push origin v1.2.3"),
+      "Should push the tag"
+    assert command_issued?(/git fetch origin stage:stage main:main/),
+      "Should fetch staging and production branches"
+  end
+
+  def test_auto_deploy_mode_creates_pr_then_merges_working_branch
+    task = build_task(:rel_auto_seq, auto_deploy: true)
+    task.define
+    $stdin = StringIO.new("\n")
+
+    capture_io { Rake::Task["rel_auto_seq"].invoke }
+
+    assert command_issued?(/gh pr create --base main --head develop/),
+      "Auto-deploy should create PR from working branch to production"
+    assert command_issued?("gh pr merge develop --merge"),
+      "Auto-deploy should merge working branch (not staging)"
+    assert command_issued?(/git tag -a v1\.2\.3 .+ main/),
+      "Should tag production branch"
+    assert command_issued?("git push origin v1.2.3"),
+      "Should push the tag"
+    assert command_issued?("git fetch origin main:main develop"),
+      "Should fetch production branch and working branch tracking ref"
+    assert command_issued?("git reset --hard origin/develop"),
+      "Should reset working branch to match remote"
+  end
+
+  def test_auto_deploy_mode_pr_create_precedes_merge
+    task = build_task(:rel_order_seq, auto_deploy: true)
+    task.define
+    $stdin = StringIO.new("\n")
+
+    capture_io { Rake::Task["rel_order_seq"].invoke }
+
+    create_idx = @commands.index { |c| c.join(" ").match?(/gh pr create/) }
+    merge_idx = @commands.index { |c| c.join(" ").match?(/gh pr merge/) }
+
+    assert create_idx, "Expected gh pr create command"
+    assert merge_idx, "Expected gh pr merge command"
+    assert_operator create_idx, :<, merge_idx,
+      "PR create must precede PR merge"
+  end
+
+  def test_auto_deploy_mode_reuses_existing_pr
+    task = build_task(:rel_reuse_seq, auto_deploy: true)
+    task.define_singleton_method(:existing_pr_number) { |*_args| "42" }
+    task.define
+    $stdin = StringIO.new("\n")
+
+    capture_io { Rake::Task["rel_reuse_seq"].invoke }
+
+    refute command_issued?(/gh pr create/),
+      "Should not create a PR when one already exists"
+    assert command_issued?("gh pr merge 42 --merge"),
+      "Should merge by PR number when reusing an existing PR"
+  end
+end
+
+class DischargerExistingPrNumberTest < Minitest::Test
+  FakeStatus = Struct.new(:ok) do
+    def success? = ok
+  end
+
+  def setup
+    @task = Discharger::Task.new
+    @original_capture3 = Open3.method(:capture3)
+  end
+
+  def teardown
+    Open3.define_singleton_method(:capture3, @original_capture3)
+  end
+
+  def stub_capture3(stdout, stderr, success)
+    status = FakeStatus.new(success)
+    Open3.define_singleton_method(:capture3) { |*_args| [stdout, stderr, status] }
+  end
+
+  def test_returns_pr_number_when_pr_exists
+    stub_capture3("42\n", "", true)
+    assert_equal "42", @task.existing_pr_number("main", "develop")
+  end
+
+  def test_returns_nil_when_no_pr_exists
+    stub_capture3("", "", true)
+    assert_nil @task.existing_pr_number("main", "develop")
+  end
+
+  def test_returns_nil_on_command_failure
+    stub_capture3("", "error", false)
+    assert_nil @task.existing_pr_number("main", "develop")
+  end
+end


### PR DESCRIPTION
## Summary

Replace direct push to `main` in Step 3 of the release process with `gh pr merge`, enabling branch protection on production branches without requiring bypass access. Resolves [QUAL-6315](https://linear.app/sofwarellc/issue/QUAL-6315).

## Changes

### Release process (standard mode)
- Replace `git reset --hard stage` + `git push origin main:main` with `gh pr merge stage --merge`
- Tag the production ref directly (`git tag -a v{version} production`) instead of checking out the production branch
- Only push the tag — the PR merge handles updating the production branch

### Release process (auto_deploy_staging mode)
- Create a PR from working branch to production via `gh pr create` (since Step 2 is skipped in this mode)
- Idempotent PR creation — checks for an existing open PR before creating a new one, reuses it if found
- Merge by PR number when reusing to avoid ambiguity
- Fix `git fetch` into checked-out branch — fetch the tracking ref and `git reset --hard` instead

### Tests
- Command sequence tests for both standard and auto_deploy_staging modes
- Ordering test verifying PR create precedes merge
- PR reuse test verifying existing PRs are reused and merged by number
- Unit tests for `existing_pr_number` covering success, empty result, and command failure

## Files changed
- `lib/discharger/task.rb` — release logic and new `existing_pr_number` helper
- `test/task_test.rb` — 7 new tests across 2 test classes
- `CHANGELOG.md` — changelog entry