### PR TITLE
Remove --user postgres from docker container creation

### DIFF
--- a/lib/discharger/setup_runner/commands/docker_command.rb
+++ b/lib/discharger/setup_runner/commands/docker_command.rb
@@ -98,7 +98,7 @@ module Discharger
         def create_container(name:, port:, image:, internal_port:, env: {}, volume: nil)
           log "Creating new #{name} container"
 
-          cmd = ["docker", "run", "-d", "--name", name, "--user", "postgres", "-p", "#{port}:#{internal_port}"]
+          cmd = ["docker", "run", "-d", "--name", name, "-p", "#{port}:#{internal_port}"]
           env.each { |k, v| cmd.push("-e", "#{k}=#{v}") }
           cmd.push("-v", volume) if volume
           cmd.push(image)

--- a/test/setup_runner/commands/docker_command_test.rb
+++ b/test/setup_runner/commands/docker_command_test.rb
@@ -245,7 +245,7 @@ class DockerCommandTest < ActiveSupport::TestCase
     @command.define_singleton_method(:system_quiet) do |cmd|
       case cmd
       when /docker ps.*db-test/
-        commands_run.include?("docker run -d --name db-test --user postgres -p 5432:5432 -e POSTGRES_PASSWORD=postgres -v db-test:/var/lib/postgresql/data postgres:14")
+        commands_run.include?("docker run -d --name db-test -p 5432:5432 -e POSTGRES_PASSWORD=postgres -v db-test:/var/lib/postgresql/data postgres:14")
       when /docker inspect db-test/
         true
       when /docker start db-test/


### PR DESCRIPTION
## Summary
- Remove hardcoded `--user postgres` flag from `create_container` in `DockerCommand`
- The flag caused non-postgres images (e.g. Redis) to fail with "unable to find user postgres"
- The postgres image handles user switching internally via its entrypoint, so the flag was redundant

## Test plan
- [x] Verify `bin/setup` creates both postgres and redis containers successfully
- [ ] Verify existing postgres containers continue to work without `--user postgres`

🤖 Generated with [Claude Code](https://claude.com/claude-code)