### PR TITLE
Fix infinite loop in pg-tools fallback when Docker is not running

### DIFF
--- a/lib/discharger/setup_runner/commands/pg_tools_command.rb
+++ b/lib/discharger/setup_runner/commands/pg_tools_command.rb
@@ -104,8 +104,16 @@ module Discharger
               exit 0
             fi
 
-            # Fallback to system pg_dump
-            exec pg_dump "$@"
+            # Fallback to system pg_dump (skip this wrapper in PATH to avoid infinite loop)
+            SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+            CLEAN_PATH="${PATH//$SCRIPT_DIR:/}"
+            CLEAN_PATH="${CLEAN_PATH%:$SCRIPT_DIR}"
+            FALLBACK=$(PATH="$CLEAN_PATH" command -v pg_dump 2>/dev/null)
+            if [[ -n "$FALLBACK" ]]; then
+              exec "$FALLBACK" "$@"
+            fi
+            echo "Error: pg_dump not found. Start Docker or install PostgreSQL client tools." >&2
+            exit 1
           BASH
         end
 
@@ -124,6 +132,7 @@ module Discharger
               # When running in Docker, host paths don't exist in the container
               # so we pipe file content via stdin instead
               INPUT_FILE=""
+              HAS_USER=""
               ARGS=()
               while [[ $# -gt 0 ]]; do
                 case $1 in
@@ -139,12 +148,22 @@ module Discharger
                     INPUT_FILE="$2"
                     shift 2
                     ;;
+                  -U|--username|--username=*)
+                    HAS_USER="1"
+                    ARGS+=("$1")
+                    shift
+                    ;;
                   *)
                     ARGS+=("$1")
                     shift
                     ;;
                 esac
               done
+
+              # Default to postgres user if not specified (container runs as root)
+              if [[ -z "$HAS_USER" ]]; then
+                ARGS=("-U" "postgres" "${ARGS[@]}")
+              fi
 
               if [[ -n "$INPUT_FILE" ]]; then
                 docker exec -i "$CONTAINER" #{tool} "${ARGS[@]}" < "$INPUT_FILE"
@@ -154,8 +173,16 @@ module Discharger
               exit 0
             fi
 
-            # Fallback to system #{tool}
-            exec #{tool} "$@"
+            # Fallback to system #{tool} (skip this wrapper in PATH to avoid infinite loop)
+            SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+            CLEAN_PATH="${PATH//$SCRIPT_DIR:/}"
+            CLEAN_PATH="${CLEAN_PATH%:$SCRIPT_DIR}"
+            FALLBACK=$(PATH="$CLEAN_PATH" command -v #{tool} 2>/dev/null)
+            if [[ -n "$FALLBACK" ]]; then
+              exec "$FALLBACK" "$@"
+            fi
+            echo "Error: #{tool} not found. Start Docker or install PostgreSQL client tools." >&2
+            exit 1
           BASH
         end
 

--- a/test/setup_runner/commands/pg_tools_command_test.rb
+++ b/test/setup_runner/commands/pg_tools_command_test.rb
@@ -1,0 +1,133 @@
+require "test_helper"
+require "setup_runner_test_helper"
+require "discharger/setup_runner/commands/pg_tools_command"
+require "logger"
+require "ostruct"
+
+class PgToolsCommandTest < ActiveSupport::TestCase
+  include SetupRunnerTestHelper
+
+  def setup
+    super
+    @config = OpenStruct.new(database: OpenStruct.new(name: "db-testapp"))
+    @logger = Logger.new(StringIO.new)
+    @command = Discharger::SetupRunner::Commands::PgToolsCommand.new(@config, @test_dir, @logger)
+  end
+
+  test "description returns correct text" do
+    assert_equal "Setting up PostgreSQL tools wrappers", @command.description
+  end
+
+  test "can_execute? returns true when database config has name" do
+    assert @command.can_execute?
+  end
+
+  test "can_execute? returns false when database config is missing" do
+    config = OpenStruct.new
+    command = Discharger::SetupRunner::Commands::PgToolsCommand.new(config, @test_dir, @logger)
+    refute command.can_execute?
+  end
+
+  test "can_execute? returns false when database name is blank" do
+    config = OpenStruct.new(database: OpenStruct.new(name: ""))
+    command = Discharger::SetupRunner::Commands::PgToolsCommand.new(config, @test_dir, @logger)
+    refute command.can_execute?
+  end
+
+  test "execute creates bin/pg-tools directory" do
+    capture_output { @command.execute }
+    assert File.directory?(File.join(@test_dir, "bin", "pg-tools"))
+  end
+
+  test "execute creates executable pg_dump wrapper" do
+    capture_output { @command.execute }
+    wrapper = File.join(@test_dir, "bin", "pg-tools", "pg_dump")
+    assert_file_exists wrapper
+    assert File.executable?(wrapper)
+  end
+
+  test "execute creates executable psql wrapper" do
+    capture_output { @command.execute }
+    wrapper = File.join(@test_dir, "bin", "pg-tools", "psql")
+    assert_file_exists wrapper
+    assert File.executable?(wrapper)
+  end
+
+  test "pg_dump wrapper uses correct container name" do
+    capture_output { @command.execute }
+    assert_file_contains File.join(@test_dir, "bin", "pg-tools", "pg_dump"), 'CONTAINER="db-testapp"'
+  end
+
+  test "psql wrapper uses correct container name" do
+    capture_output { @command.execute }
+    assert_file_contains File.join(@test_dir, "bin", "pg-tools", "psql"), 'CONTAINER="db-testapp"'
+  end
+
+  test "pg_dump wrapper fallback strips script dir from PATH to avoid infinite loop" do
+    capture_output { @command.execute }
+    content = File.read(File.join(@test_dir, "bin", "pg-tools", "pg_dump"))
+    assert_includes content, "SCRIPT_DIR="
+    assert_includes content, 'CLEAN_PATH="${PATH//$SCRIPT_DIR:/}"'
+    assert_includes content, 'exec "$FALLBACK"'
+  end
+
+  test "psql wrapper fallback strips script dir from PATH to avoid infinite loop" do
+    capture_output { @command.execute }
+    content = File.read(File.join(@test_dir, "bin", "pg-tools", "psql"))
+    assert_includes content, "SCRIPT_DIR="
+    assert_includes content, 'CLEAN_PATH="${PATH//$SCRIPT_DIR:/}"'
+    assert_includes content, 'exec "$FALLBACK"'
+  end
+
+  test "pg_dump wrapper fallback shows error when no binary found" do
+    capture_output { @command.execute }
+    content = File.read(File.join(@test_dir, "bin", "pg-tools", "pg_dump"))
+    assert_includes content, "Error: pg_dump not found"
+    assert_includes content, "exit 1"
+  end
+
+  test "psql wrapper fallback shows error when no binary found" do
+    capture_output { @command.execute }
+    content = File.read(File.join(@test_dir, "bin", "pg-tools", "psql"))
+    assert_includes content, "Error: psql not found"
+    assert_includes content, "exit 1"
+  end
+
+  test "pg_dump wrapper defaults to -U postgres" do
+    capture_output { @command.execute }
+    content = File.read(File.join(@test_dir, "bin", "pg-tools", "pg_dump"))
+    assert_includes content, 'ARGS=("-U" "postgres" "${ARGS[@]}")'
+  end
+
+  test "psql wrapper defaults to -U postgres" do
+    capture_output { @command.execute }
+    content = File.read(File.join(@test_dir, "bin", "pg-tools", "psql"))
+    assert_includes content, 'ARGS=("-U" "postgres" "${ARGS[@]}")'
+  end
+
+  test "execute creates envrc when none exists" do
+    capture_output { @command.execute }
+    assert_file_contains File.join(@test_dir, ".envrc"), "PATH_add bin/pg-tools"
+  end
+
+  test "execute does not overwrite existing envrc" do
+    existing_content = "export FOO=bar\n"
+    create_file(".envrc", existing_content)
+    capture_output { @command.execute }
+    assert_equal existing_content, File.read(File.join(@test_dir, ".envrc"))
+  end
+
+  test "pg_dump wrapper does not fallback with bare exec that could self-recurse" do
+    capture_output { @command.execute }
+    content = File.read(File.join(@test_dir, "bin", "pg-tools", "pg_dump"))
+    # Should NOT contain a bare "exec pg_dump" without the FALLBACK variable
+    refute_match(/^exec pg_dump/, content)
+  end
+
+  test "psql wrapper does not fallback with bare exec that could self-recurse" do
+    capture_output { @command.execute }
+    content = File.read(File.join(@test_dir, "bin", "pg-tools", "psql"))
+    # Should NOT contain a bare "exec psql" without the FALLBACK variable
+    refute_match(/^exec psql/, content)
+  end
+end


### PR DESCRIPTION
## Summary

- Fix infinite recursion in generated `bin/pg-tools/pg_dump` and `bin/pg-tools/psql` wrappers when Docker is not running
- Add `-U postgres` default to `psql` wrapper (was missing, `pg_dump` already had it)
- Add tests for `PgToolsCommand` (previously untested)

## Business Justification

The fallback `exec pg_dump "$@"` resolves back to the wrapper itself because `bin/pg-tools/` is prepended to PATH (via the Railtie and `.envrc`), creating infinite recursion. Any developer running `rails db:schema:dump` or similar with Docker stopped would hang indefinitely. Fix strips the wrapper directory from PATH before searching for the system binary.

## Technical Details

**Root cause:** PR #150 (2025-12-19) introduced the wrappers with a bare `exec pg_dump "$@"` fallback, but also added a Railtie that prepends `bin/pg-tools/` to PATH. The fallback finds itself instead of the system binary.

**Fix:** Replace bare `exec` fallback with PATH-aware resolution that handles the wrapper directory at any position in PATH:
```bash
SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
CLEAN_PATH="${PATH//$SCRIPT_DIR:/}"
CLEAN_PATH="${CLEAN_PATH%:$SCRIPT_DIR}"
FALLBACK=$(PATH="$CLEAN_PATH" command -v pg_dump 2>/dev/null)
if [[ -n "$FALLBACK" ]]; then
  exec "$FALLBACK" "$@"
fi
echo "Error: pg_dump not found. Start Docker or install PostgreSQL client tools." >&2
exit 1
```

**Reproduced in Qualify:** Both wrappers confirmed to infinite-loop (timeout exit code 124) when Docker is not running. After fix, both correctly find system binaries.

Fixed: pg-tools wrappers no longer infinite loop when Docker is stopped
Fixed: psql wrapper now defaults to -U postgres like pg_dump