### PR TITLE
Update bundled gems to latest patch versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,16 +99,16 @@ GEM
       reline (>= 0.3.8)
     docile (1.4.1)
     drb (2.2.3)
-    erb (6.0.1)
+    erb (6.0.2)
     erubi (1.13.1)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-mashify (1.0.0)
+    faraday-mashify (1.0.2)
       faraday (~> 2.0)
       hashie
-    faraday-multipart (1.1.1)
+    faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
@@ -116,15 +116,17 @@ GEM
       ostruct
     globalid (1.3.0)
       activesupport (>= 6.1)
-    hashie (5.0.0)
+    hashie (5.1.0)
+      logger
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    irb (1.16.0)
+    irb (1.17.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.1)
+    json (2.19.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -140,12 +142,13 @@ GEM
     marcel (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.1)
+    minitest (6.0.2)
+      drb (~> 2.0)
       prism (~> 1.5)
     multipart-post (2.4.1)
-    net-http (0.8.0)
+    net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.2)
+    net-imap (0.6.3)
       date
       net-protocol
     net-pop (0.1.2)
@@ -155,13 +158,13 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.0)
+    nokogiri (1.19.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     open3 (0.2.1)
     ostruct (0.6.3)
     parallel (1.27.0)
-    parser (3.3.10.1)
+    parser (3.3.10.2)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
@@ -174,7 +177,7 @@ GEM
     puma (7.2.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.2.5)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -214,12 +217,12 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
-    rdoc (7.0.3)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
     regexp_parser (2.11.3)
-    reissue (0.4.19)
+    reissue (0.4.21)
       rake
     reline (0.6.3)
       io-console (~> 0.5)
@@ -234,7 +237,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -272,7 +275,7 @@ GEM
       rubocop-performance (~> 1.26.0)
     stringio (3.2.0)
     thor (1.5.0)
-    timeout (0.6.0)
+    timeout (0.6.1)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -285,7 +288,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.4)
+    zeitwerk (2.7.5)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## Summary
- Bump 18 gems to their latest minor/patch releases
- All 203 tests pass with 0 failures
- 94.31% line coverage maintained

## Updated Gems

| Gem | From | To |
|-----|------|----|
| reissue | 0.4.19 | 0.4.21 |
| nokogiri | 1.19.0 | 1.19.1 |
| json | 2.18.1 | 2.19.1 |
| net-http | 0.8.0 | 0.9.1 |
| rdoc | 7.0.3 | 7.2.0 |
| hashie | 5.0.0 | 5.1.0 |
| faraday | 2.14.0 | 2.14.1 |
| faraday-mashify | 1.0.0 | 1.0.2 |
| faraday-multipart | 1.1.1 | 1.2.0 |
| irb | 1.16.0 | 1.17.0 |
| minitest | 6.0.1 | 6.0.2 |
| net-imap | 0.6.2 | 0.6.3 |
| parser | 3.3.10.1 | 3.3.10.2 |
| rack | 3.2.4 | 3.2.5 |
| rubocop-ast | 1.49.0 | 1.49.1 |
| timeout | 0.6.0 | 0.6.1 |
| zeitwerk | 2.7.4 | 2.7.5 |
| erb | 6.0.1 | 6.0.2 |

## Test plan
- [x] Full test suite passes (203 tests, 514 assertions)
- [x] CI green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>