### PR TITLE
Harden auto-release tagging and PR creation

### DIFF
--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -47,6 +47,7 @@ module Discharger
     attr_accessor :app_name
     attr_accessor :commit_identifier
     attr_accessor :pull_request_url
+    attr_accessor :pr_label
     attr_accessor :fragment_directory
     attr_accessor :fragment
     attr_accessor :clear_fragments
@@ -192,6 +193,31 @@ module Discharger
       abort "Working tree has uncommitted changes. Commit or stash them before running rake #{name}:prepare."
     end
 
+    def validate_pr_label!
+      return true unless pr_label
+
+      _, stderr, status = Open3.capture3("gh", "label", "view", pr_label)
+      return true if status.success?
+
+      abort <<~ERROR.bg(:red).white
+        Could not find GitHub label '#{pr_label}'.
+
+        #{stderr}
+      ERROR
+    end
+
+    # gh pr create fails when a PR already exists for the branch, so re-runs
+    # reuse it instead.
+    def create_labeled_pr!(head:, title:, body:)
+      if (pr_number = existing_pr_number(working_branch, head))
+        return sysecho("Reusing existing PR ##{pr_number} for #{head}.")
+      end
+
+      syscall(
+        ["gh pr create --base #{working_branch} --head #{head} --title '#{title}' --body '#{body}' --label '#{pr_label}'"]
+      )
+    end
+
     # Guards the reset --hard below from discarding unpushed local commits.
     def ensure_branch_not_ahead!(branch)
       stdout, _, status = Open3.capture3("git", "rev-list", "--count", "origin/#{branch}..#{branch}")
@@ -282,6 +308,7 @@ module Discharger
         unless system("gh --version > /dev/null 2>&1")
           abort "Error: GitHub CLI (gh) is required for the release process but was not found. Install it: https://cli.github.com"
         end
+        validate_pr_label!
 
         current_version = Object.const_get(version_constant)
 
@@ -369,20 +396,26 @@ module Discharger
 
         new_version_branch = `git rev-parse --abbrev-ref HEAD`.strip
         new_version = new_version_branch.split("/").last
-        params = {expand: 1, title: "Bump version to #{new_version}"}
-        pr_url = "#{pull_request_url}/compare/#{working_branch}...#{new_version_branch}?#{params.to_query}"
 
-        syscall(["git push origin #{new_version_branch} --force"]) do
-          sysecho <<~MSG
-            Branch #{new_version_branch} created.
+        if pr_label
+          syscall(["git push origin #{new_version_branch} --force"])
+          create_labeled_pr!(head: new_version_branch, title: "Bump version to #{new_version}", body: "")
+        else
+          params = {expand: 1, title: "Bump version to #{new_version}"}
+          pr_url = "#{pull_request_url}/compare/#{working_branch}...#{new_version_branch}?#{params.to_query}"
 
-            Open a PR to #{working_branch} to mark the version and update the chaneglog
-            for the next release.
+          syscall(["git push origin #{new_version_branch} --force"]) do
+            sysecho <<~MSG
+              Branch #{new_version_branch} created.
 
-            Opening PR: #{pr_url}
-          MSG
-        end.then do |success|
-          syscall ["open", pr_url] if success
+              Open a PR to #{working_branch} to mark the version and update the chaneglog
+              for the next release.
+
+              Opening PR: #{pr_url}
+            MSG
+          end.then do |success|
+            syscall ["open", pr_url] if success
+          end
         end
       end
 
@@ -453,6 +486,7 @@ module Discharger
         DESC
         task prepare: [:environment] do
           ensure_clean_worktree!
+          validate_pr_label!
 
           current_version = Object.const_get(version_constant)
           finish_branch = "bump/finish-#{current_version.tr(".", "-")}"
@@ -482,34 +516,51 @@ module Discharger
 
           tasker["reissue:finalize"].invoke
 
-          params = {
-            expand: 1,
-            title: "Finish version #{current_version}",
-            body: <<~BODY
-              Completing development for #{current_version}.
-            BODY
-          }
-
-          pr_url = "#{pull_request_url}/compare/#{finish_branch}?#{params.to_query}"
-
           next_step = auto_deploy_staging ? "rake #{name}" : "rake #{name}:stage"
           next_step_desc = auto_deploy_staging ? "release to production" : "stage the release branch"
 
-          continue = syscall ["git push origin #{finish_branch} --force"] do
+          if pr_label
+            syscall ["git push origin #{finish_branch} --force"]
+            create_labeled_pr!(
+              head: finish_branch,
+              title: "Finish version #{current_version}",
+              body: "Completing development for #{current_version}."
+            )
             sysecho <<~MSG
-              Branch #{finish_branch} created.
-              Open a PR to #{working_branch} to finalize the release.
-
-              #{pr_url}
+              Branch #{finish_branch} pushed and its PR labeled '#{pr_label}'.
 
               Once the PR is merged, pull down #{working_branch} and run
                 '#{next_step}'
               to #{next_step_desc}.
             MSG
-          end
-          if continue
-            syscall ["git checkout #{working_branch}"],
-              ["open", pr_url]
+            syscall ["git checkout #{working_branch}"]
+          else
+            params = {
+              expand: 1,
+              title: "Finish version #{current_version}",
+              body: <<~BODY
+                Completing development for #{current_version}.
+              BODY
+            }
+
+            pr_url = "#{pull_request_url}/compare/#{finish_branch}?#{params.to_query}"
+
+            continue = syscall ["git push origin #{finish_branch} --force"] do
+              sysecho <<~MSG
+                Branch #{finish_branch} created.
+                Open a PR to #{working_branch} to finalize the release.
+
+                #{pr_url}
+
+                Once the PR is merged, pull down #{working_branch} and run
+                  '#{next_step}'
+                to #{next_step_desc}.
+              MSG
+            end
+            if continue
+              syscall ["git checkout #{working_branch}"],
+                ["open", pr_url]
+            end
           end
         end
 

--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -185,6 +185,25 @@ module Discharger
       stdout
     end
 
+    def ensure_clean_worktree!
+      stdout, _, status = Open3.capture3("git", "status", "--porcelain")
+      return true if status.success? && stdout.empty?
+
+      abort "Working tree has uncommitted changes. Commit or stash them before running rake #{name}:prepare."
+    end
+
+    # Guards the reset --hard below from discarding unpushed local commits.
+    def ensure_branch_not_ahead!(branch)
+      stdout, _, status = Open3.capture3("git", "rev-list", "--count", "origin/#{branch}..#{branch}")
+      return true if status.success? && stdout.strip == "0"
+
+      abort <<~ERROR.bg(:red).white
+        Local #{branch} has commits not on origin/#{branch}. Refusing to reset --hard.
+
+        Push or remove them before retrying.
+      ERROR
+    end
+
     # The post-release steps collected from "Runbook:" commit trailers.
     # Empty when no runbook is configured or the file has yet to be written.
     def runbook_items
@@ -433,12 +452,20 @@ module Discharger
           the release.
         DESC
         task prepare: [:environment] do
+          ensure_clean_worktree!
+
           current_version = Object.const_get(version_constant)
           finish_branch = "bump/finish-#{current_version.tr(".", "-")}"
 
           syscall(
             ["git fetch origin #{working_branch}"],
-            ["git checkout #{working_branch}"],
+            ["git checkout #{working_branch}"]
+          )
+          ensure_branch_not_ahead!(working_branch)
+          # Cut the finish branch from origin, not the local branch: a stale
+          # local working branch finalizes with an empty changelog.
+          syscall(
+            ["git reset --hard origin/#{working_branch}"],
             ["git checkout -b #{finish_branch}"]
           )
           sysecho <<~MSG

--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -25,6 +25,7 @@ module Discharger
         reissue.clear_fragments = task.clear_fragments
         reissue.tag_pattern = task.tag_pattern
         reissue.runbook_file = task.runbook_file
+        reissue.retain_changelogs = task.retain_changelogs
       end
       task.define
       task

--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -135,32 +135,30 @@ module Discharger
       ERROR
     end
 
-    # Abort if HEAD is not the commit that last touched the version file
-    def validate_release_commit!(branch, output: $stdout)
-      head_sha = git_local_sha(branch)
-      release_sha = git_version_file_commit(branch)
+    # Locate the commit that finalized changelog_file for the current version.
+    # Deliberately not a gate on HEAD: PRs that merge after the finalize PR
+    # must neither block the release nor ship under its tag.
+    def find_release_commit!(branch, output: $stdout)
+      version = Object.const_get(version_constant)
+      version_header = /^## \[#{Regexp.escape(version)}\] - \d{4}-\d{2}-\d{2}/
+      sha = git_file_commits(branch, changelog_file).find do |candidate_sha|
+        next false if git_merge_commit?(candidate_sha)
 
-      if head_sha.nil? || release_sha.nil?
+        contents = git_show_at_commit(candidate_sha, changelog_file)
+        parent_contents = git_show_at_commit("#{candidate_sha}^", changelog_file)
+
+        contents&.match?(version_header) && !parent_contents&.match?(version_header)
+      end
+
+      if sha.nil?
         abort <<~ERROR.bg(:red).white
-          Could not determine release commit.
-
-          HEAD:           #{head_sha || "not found"}
-          Release commit: #{release_sha || "not found"}
-
-          Ensure #{branch} exists and #{version_file} has been modified.
+          Could not locate a release commit.
+          Ensure #{branch} exists and #{changelog_file} has been finalized for #{version}.
         ERROR
       end
 
-      return sysecho("✓ HEAD is the release commit (#{head_sha[0, 8]})".bg(:green).black, output:) if head_sha == release_sha
-
-      abort <<~ERROR.bg(:red).white
-        HEAD is not the release commit!
-
-        HEAD:           #{head_sha[0, 8]}
-        Release commit: #{release_sha[0, 8]} (last commit to touch #{version_file})
-
-        Something was merged after the release PR. Verify the branch contents and retry.
-      ERROR
+      sysecho("✓ Release commit: #{sha[0, 8]}".bg(:green).black, output:)
+      sha
     end
 
     def git_show_version(branch)
@@ -169,16 +167,22 @@ module Discharger
       content[/VERSION\s*=\s*["']([^"']+)["']/, 1]
     end
 
-    def git_local_sha(branch)
-      stdout, _, status = Open3.capture3("git", "rev-parse", branch)
-      return nil unless status.success?
-      stdout.strip
+    def git_file_commits(branch, path)
+      stdout, _, status = Open3.capture3("git", "log", "--no-merges", branch, "--format=%H", "--", path)
+      return [] unless status.success?
+      stdout.lines.map(&:strip)
     end
 
-    def git_version_file_commit(branch)
-      stdout, _, status = Open3.capture3("git", "log", branch, "-1", "--format=%H", "--", version_file)
+    def git_merge_commit?(sha)
+      stdout, _, status = Open3.capture3("git", "rev-list", "--parents", "-n", "1", sha)
+      return false unless status.success?
+      stdout.split.length > 2
+    end
+
+    def git_show_at_commit(sha, path)
+      stdout, _, status = Open3.capture3("git", "show", "#{sha}:#{path}")
       return nil unless status.success?
-      stdout.strip
+      stdout
     end
 
     # The post-release steps collected from "Runbook:" commit trailers.
@@ -266,10 +270,16 @@ module Discharger
         # instead of staging_branch (for CI/CD pipelines that auto-deploy staging)
         release_source = auto_deploy_staging ? working_branch : staging_branch
 
+        release_action = if auto_deploy_staging
+          "This will tag the release commit on #{working_branch} and push the tag."
+        else
+          "This will tag the current version and push it to the production branch."
+        end
+
         sysecho <<~MSG
           Releasing version #{current_version} to production.
 
-          This will tag the current version and push it to the production branch.
+          #{release_action}
           Release source: #{release_source}
         MSG
         sysecho "Are you ready to continue? (Press Enter to continue, Type 'x' and Enter to exit)".bg(:yellow).black
@@ -284,48 +294,41 @@ module Discharger
 
         if auto_deploy_staging
           syscall(
-            ["git fetch origin #{production_branch}:#{production_branch} #{working_branch}"],
+            ["git fetch origin #{working_branch}"],
             ["git reset --hard origin/#{working_branch}"]
           )
-          validate_release_commit!(release_source)
+          # Tag the finalize commit itself: origin/working_branch may already
+          # carry work merged after the finalize PR.
+          tag_ref = find_release_commit!(release_source)
         else
           syscall(
             ["git fetch origin #{release_source}:#{release_source} #{production_branch}:#{production_branch}"]
           )
           validate_version_match!(staging_branch, working_branch)
-        end
 
-        pr_ref = release_source
-        if auto_deploy_staging
-          pr_number = existing_pr_number(production_branch, release_source)
-          if pr_number
-            sysecho "Reusing existing PR ##{pr_number} from #{release_source} to #{production_branch}."
-            pr_ref = pr_number
+          pr_ref = release_source
+          if pr_already_merged?(pr_ref)
+            sysecho "PR #{pr_ref} is already merged. Continuing..."
           else
             syscall(
-              ["gh pr create --base #{production_branch} --head #{release_source} --title 'Release #{current_version}' --body 'Deploy #{current_version} to production.'"]
+              ["gh pr merge #{pr_ref} --merge"]
             )
           end
+
+          syscall(["git fetch origin #{production_branch}:#{production_branch}"])
+          tag_ref = production_branch
         end
 
-        if pr_already_merged?(pr_ref)
-          sysecho "PR #{pr_ref} is already merged. Continuing..."
-        else
-          syscall(
-            ["gh pr merge #{pr_ref} --merge"]
-          )
-        end
-
+        slack_sha = auto_deploy_staging ? tag_ref[0, 8] : commit_identifier.call
         continue = syscall(
-          ["git fetch origin #{production_branch}:#{production_branch}"],
-          ["git tag -a v#{current_version} -m 'Release #{current_version}' #{production_branch}"],
+          ["git tag -a v#{current_version} -m 'Release #{current_version}' #{tag_ref}"],
           ["git push origin v#{current_version}"]
         ) do
-          tasker["#{name}:slack"].invoke("Released #{app_name} #{current_version} (#{commit_identifier.call}) to production.", release_message_channel, ":chipmunk:")
+          tasker["#{name}:slack"].invoke("Released #{app_name} #{current_version} (#{slack_sha}) to production.", release_message_channel, ":chipmunk:")
           # Capture the root before replying; each post overwrites last_message_ts.
           thread_ts = last_message_ts
           if thread_ts.present?
-            text = File.read(Rails.root.join(changelog_file))
+            text = git_show_at_commit(tag_ref, changelog_file) || File.read(Rails.root.join(changelog_file))
             tasker["#{name}:slack"].reenable
             tasker["#{name}:slack"].invoke(text, release_message_channel, ":log:", thread_ts)
 

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -59,6 +59,28 @@ class DischargerTaskTest < Minitest::Test
     Reissue::Task.define_singleton_method(:create, original_create)
   end
 
+  def test_create_forwards_retain_changelogs_to_reissue
+    retainer = ->(version_hash, content) { [version_hash, content] }
+    captured_retain_changelogs = nil
+
+    original_create = Reissue::Task.method(:create)
+    Reissue::Task.define_singleton_method(:create) do |name = :reissue, &block|
+      reissue_task = Reissue::Task.new(name)
+      block&.call(reissue_task)
+      captured_retain_changelogs = reissue_task.retain_changelogs
+      reissue_task
+    end
+
+    Discharger::Task.create(:test_retain_changelogs) do
+      self.version_file = "VERSION"
+      self.retain_changelogs = retainer
+    end
+
+    assert_equal retainer, captured_retain_changelogs
+  ensure
+    Reissue::Task.define_singleton_method(:create, original_create)
+  end
+
   def test_syscall_success
     output = StringIO.new
     assert_output(/Hello, World!/) do

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -246,7 +246,7 @@ class DischargerReleaseCommandSequenceTest < Minitest::Test
     $stdin = @original_stdin
   end
 
-  def build_task(name, auto_deploy:)
+  def build_task(name, auto_deploy:, pr_label: nil)
     noop_task = Object.new
     noop_task.define_singleton_method(:invoke) { |*_args| }
     noop_task.define_singleton_method(:reenable) {}
@@ -263,6 +263,7 @@ class DischargerReleaseCommandSequenceTest < Minitest::Test
     task.app_name = "TestApp"
     task.commit_identifier = -> { "abc123" }
     task.auto_deploy_staging = auto_deploy
+    task.pr_label = pr_label
 
     commands = @commands
     task.define_singleton_method(:syscall) do |*steps, **_kwargs, &_block|
@@ -350,6 +351,53 @@ class DischargerReleaseCommandSequenceTest < Minitest::Test
       "Unpushed-commit check must run before the reset"
   end
 
+  def test_prepare_creates_labeled_pr_when_pr_label_is_set
+    task = build_task(:rel_prep_label, auto_deploy: true, pr_label: "no-changelog-needed")
+    task.define_singleton_method(:ensure_clean_worktree!) { true }
+    task.define_singleton_method(:ensure_branch_not_ahead!) { |_branch| true }
+    task.define_singleton_method(:validate_pr_label!) { true }
+    task.define_singleton_method(:existing_pr_number) { |*_args| nil }
+    task.define
+    $stdin = StringIO.new("\n")
+
+    capture_io { Rake::Task["rel_prep_label:prepare"].invoke }
+
+    assert command_issued?("gh pr create --base develop --head bump/finish-1-2-3 --title 'Finish version 1.2.3' --body 'Completing development for 1.2.3.' --label 'no-changelog-needed'"),
+      "Should create the finish PR with the configured label"
+    refute command_issued?(/^open /),
+      "Should not open a browser compare page when the PR is created directly"
+  end
+
+  def test_prepare_keeps_compare_url_flow_without_pr_label
+    task = build_task(:rel_prep_nolabel, auto_deploy: true)
+    task.define_singleton_method(:ensure_clean_worktree!) { true }
+    task.define_singleton_method(:ensure_branch_not_ahead!) { |_branch| true }
+    task.define
+    $stdin = StringIO.new("\n")
+
+    capture_io { Rake::Task["rel_prep_nolabel:prepare"].invoke }
+
+    refute command_issued?(/gh pr create/),
+      "Should not create a PR without a configured label"
+    assert command_issued?(/^open http/),
+      "Should open the compare URL"
+  end
+
+  def test_release_creates_labeled_bump_pr_when_pr_label_is_set
+    task = build_task(:rel_bump_label, auto_deploy: true, pr_label: "no-changelog-needed")
+    task.define_singleton_method(:validate_pr_label!) { true }
+    task.define_singleton_method(:existing_pr_number) { |*_args| nil }
+    task.define
+    $stdin = StringIO.new("\n")
+
+    capture_io { Rake::Task["rel_bump_label"].invoke }
+
+    assert command_issued?(/gh pr create --base develop --head \S+ --title 'Bump version to \S+' --body '' --label 'no-changelog-needed'/),
+      "Should create the bump PR with the configured label"
+    refute command_issued?(/^open /),
+      "Should not open a browser compare page for the bump PR"
+  end
+
   def test_standard_mode_skips_merge_when_pr_already_merged
     task = build_task(:rel_merged_seq, auto_deploy: false)
     task.define_singleton_method(:pr_already_merged?) { |_ref| true }
@@ -424,6 +472,65 @@ class DischargerReleasePreconditionTest < Minitest::Test
     @task.ensure_branch_not_ahead!("develop")
 
     assert_includes captured, "origin/develop..develop"
+  end
+
+  def test_validate_pr_label_returns_true_without_label
+    assert @task.validate_pr_label!
+  end
+
+  def test_validate_pr_label_queries_the_configured_label
+    @task.pr_label = "no-changelog-needed"
+    captured = nil
+    status = FakeStatus.new(true)
+    Open3.define_singleton_method(:capture3) { |*args|
+      captured = args
+      ["", "", status]
+    }
+
+    assert @task.validate_pr_label!
+    assert_equal ["gh", "label", "view", "no-changelog-needed"], captured
+  end
+
+  def test_validate_pr_label_aborts_when_label_is_missing
+    @task.pr_label = "no-changelog-needed"
+    stub_capture3("", "not found", false)
+
+    assert_raises(SystemExit) do
+      capture_io { @task.validate_pr_label! }
+    end
+  end
+
+  def test_create_labeled_pr_creates_pr_with_label
+    @task.pr_label = "no-changelog-needed"
+    @task.define_singleton_method(:existing_pr_number) { |*_args| nil }
+    created = nil
+    @task.define_singleton_method(:syscall) { |*steps|
+      created = steps
+      true
+    }
+
+    @task.create_labeled_pr!(head: "bump/finish-1-2-3", title: "Finish version 1.2.3", body: "Completing development for 1.2.3.")
+
+    assert_equal [["gh pr create --base develop --head bump/finish-1-2-3 --title 'Finish version 1.2.3' --body 'Completing development for 1.2.3.' --label 'no-changelog-needed'"]], created
+  end
+
+  def test_create_labeled_pr_reuses_existing_pr
+    @task.pr_label = "no-changelog-needed"
+    @task.define_singleton_method(:existing_pr_number) { |*_args| "17" }
+    created = false
+    @task.define_singleton_method(:syscall) { |*_steps|
+      created = true
+    }
+    echoed = nil
+    @task.define_singleton_method(:sysecho) { |message, **_kwargs|
+      echoed = message
+      true
+    }
+
+    @task.create_labeled_pr!(head: "bump/finish-1-2-3", title: "Finish version 1.2.3", body: "")
+
+    refute created, "Should not run gh pr create when a PR already exists"
+    assert_match(/Reusing existing PR #17/, echoed)
   end
 end
 

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -324,6 +324,32 @@ class DischargerReleaseCommandSequenceTest < Minitest::Test
       "Should reset working branch to match remote"
   end
 
+  def test_prepare_resets_working_branch_from_origin_before_branching
+    task = build_task(:rel_prep_seq, auto_deploy: true)
+    ahead_checked_at = nil
+    commands = @commands
+    task.define_singleton_method(:ensure_clean_worktree!) { true }
+    task.define_singleton_method(:ensure_branch_not_ahead!) { |_branch|
+      ahead_checked_at = commands.length
+      true
+    }
+    task.define
+    $stdin = StringIO.new("\n")
+
+    capture_io { Rake::Task["rel_prep_seq:prepare"].invoke }
+
+    reset_idx = @commands.index { |c| c.join(" ") == "git reset --hard origin/develop" }
+    branch_idx = @commands.index { |c| c.join(" ") == "git checkout -b bump/finish-1-2-3" }
+
+    assert reset_idx, "Expected a reset from origin"
+    assert branch_idx, "Expected the finish branch to be created"
+    assert_operator reset_idx, :<, branch_idx,
+      "Finish branch must be cut after resetting to origin"
+    assert ahead_checked_at, "Expected the unpushed-commit check to run"
+    assert_operator ahead_checked_at, :<=, reset_idx,
+      "Unpushed-commit check must run before the reset"
+  end
+
   def test_standard_mode_skips_merge_when_pr_already_merged
     task = build_task(:rel_merged_seq, auto_deploy: false)
     task.define_singleton_method(:pr_already_merged?) { |_ref| true }
@@ -338,6 +364,66 @@ class DischargerReleaseCommandSequenceTest < Minitest::Test
       "Should still tag production branch"
     assert command_issued?("git push origin v1.2.3"),
       "Should still push the tag"
+  end
+end
+
+class DischargerReleasePreconditionTest < Minitest::Test
+  FakeStatus = Struct.new(:ok) do
+    def success? = ok
+  end
+
+  def setup
+    @task = Discharger::Task.new
+    @original_capture3 = Open3.method(:capture3)
+  end
+
+  def teardown
+    Open3.define_singleton_method(:capture3, @original_capture3)
+  end
+
+  def stub_capture3(stdout, stderr, success)
+    status = FakeStatus.new(success)
+    Open3.define_singleton_method(:capture3) { |*_args| [stdout, stderr, status] }
+  end
+
+  def test_ensure_clean_worktree_allows_clean_checkout
+    stub_capture3("", "", true)
+
+    assert @task.ensure_clean_worktree!
+  end
+
+  def test_ensure_clean_worktree_aborts_on_dirty_checkout
+    stub_capture3(" M CHANGELOG.md\n", "", true)
+
+    assert_raises(SystemExit) do
+      capture_io { @task.ensure_clean_worktree! }
+    end
+  end
+
+  def test_ensure_branch_not_ahead_passes_when_count_is_zero
+    stub_capture3("0\n", "", true)
+    assert @task.ensure_branch_not_ahead!("develop")
+  end
+
+  def test_ensure_branch_not_ahead_aborts_when_local_has_unpushed_commits
+    stub_capture3("3\n", "", true)
+
+    assert_raises(SystemExit) do
+      capture_io { @task.ensure_branch_not_ahead!("develop") }
+    end
+  end
+
+  def test_ensure_branch_not_ahead_counts_commits_missing_from_origin
+    captured = nil
+    status = FakeStatus.new(true)
+    Open3.define_singleton_method(:capture3) { |*args|
+      captured = args
+      ["0\n", "", status]
+    }
+
+    @task.ensure_branch_not_ahead!("develop")
+
+    assert_includes captured, "origin/develop..develop"
   end
 end
 

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -147,31 +147,82 @@ class DischargerTaskTest < Minitest::Test
     end
   end
 
-  def test_validate_release_commit_success
-    sha = "abc123def456"
+  TEST_VERSION = "1.2.3"
 
-    # Stub both methods to return same SHA
-    @task.define_singleton_method(:git_local_sha) { |_branch| sha }
-    @task.define_singleton_method(:git_version_file_commit) { |_branch| sha }
+  def test_find_release_commit_returns_sha_that_introduced_version_header
+    later_sha = "later123def456"
+    finalize_sha = "final123def456"
+    @task.changelog_file = "CHANGELOG.md"
+    @task.version_constant = "DischargerTaskTest::TEST_VERSION"
+    @task.define_singleton_method(:git_file_commits) { |_branch, _path| [later_sha, finalize_sha] }
+    @task.define_singleton_method(:git_merge_commit?) { |_sha| false }
+    @task.define_singleton_method(:git_show_at_commit) do |ref, _path|
+      case ref
+      when later_sha
+        "## [1.2.3] - 2026-04-20\n\n### Changed\n- Later edit\n"
+      when "#{later_sha}^"
+        "## [1.2.3] - 2026-04-20\n\n### Changed\n- Thing\n"
+      when finalize_sha
+        "## [1.2.3] - 2026-04-20\n\n### Changed\n- Thing\n"
+      when "#{finalize_sha}^"
+        "## [1.2.3] - Unreleased\n\n### Changed\n- Thing\n"
+      end
+    end
 
     output = StringIO.new
-    result = @task.validate_release_commit!("develop", output:)
+    result = @task.find_release_commit!("develop", output:)
 
-    assert result
-    assert_match(/HEAD is the release commit/, output.string)
+    assert_equal finalize_sha, result
+    assert_match(/Release commit/, output.string)
   end
 
-  def test_validate_release_commit_failure
-    head_sha = "abc123def456"
-    release_sha = "xyz789ghi012"
+  def test_find_release_commit_skips_merge_commit_that_looks_like_finalize
+    merge_sha = "merge123def456"
+    finalize_sha = "final123def456"
+    @task.changelog_file = "CHANGELOG.md"
+    @task.version_constant = "DischargerTaskTest::TEST_VERSION"
+    @task.define_singleton_method(:git_file_commits) { |_branch, _path| [merge_sha, finalize_sha] }
+    @task.define_singleton_method(:git_merge_commit?) { |sha| sha == merge_sha }
+    @task.define_singleton_method(:git_show_at_commit) do |ref, _path|
+      case ref
+      when merge_sha
+        "## [1.2.3] - 2026-04-20\n\n### Changed\n- Thing\n"
+      when "#{merge_sha}^"
+        "## [1.2.3] - Unreleased\n\n### Changed\n- Thing\n"
+      when finalize_sha
+        "## [1.2.3] - 2026-04-20\n\n### Changed\n- Thing\n"
+      when "#{finalize_sha}^"
+        "## [1.2.3] - Unreleased\n\n### Changed\n- Thing\n"
+      end
+    end
 
-    # Stub to return different SHAs
-    @task.define_singleton_method(:git_local_sha) { |_branch| head_sha }
-    @task.define_singleton_method(:git_version_file_commit) { |_branch| release_sha }
-    @task.version_file = "VERSION"
+    output = StringIO.new
+    result = @task.find_release_commit!("develop", output:)
+
+    assert_equal finalize_sha, result
+  end
+
+  def test_find_release_commit_aborts_when_no_commit_touches_changelog
+    @task.changelog_file = "CHANGELOG.md"
+    @task.version_constant = "DischargerTaskTest::TEST_VERSION"
+    @task.define_singleton_method(:git_file_commits) { |_branch, _path| [] }
 
     assert_raises(SystemExit) do
-      capture_io { @task.validate_release_commit!("develop") }
+      capture_io { @task.find_release_commit!("develop") }
+    end
+  end
+
+  def test_find_release_commit_aborts_when_version_header_missing
+    @task.changelog_file = "CHANGELOG.md"
+    @task.version_constant = "DischargerTaskTest::TEST_VERSION"
+    @task.define_singleton_method(:git_file_commits) { |_branch, _path| ["abc123def456"] }
+    @task.define_singleton_method(:git_merge_commit?) { |_sha| false }
+    @task.define_singleton_method(:git_show_at_commit) do |_ref, _path|
+      "## [9.9.9] - 2020-01-01\n\n### Changed\n- Old thing\n"
+    end
+
+    assert_raises(SystemExit) do
+      capture_io { @task.find_release_commit!("develop") }
     end
   end
 
@@ -183,6 +234,7 @@ end
 
 class DischargerReleaseCommandSequenceTest < Minitest::Test
   FAKE_VERSION = "1.2.3"
+  FAKE_RELEASE_SHA = "f4c0ffee1234567890abcdef"
 
   def setup
     @commands = []
@@ -219,8 +271,7 @@ class DischargerReleaseCommandSequenceTest < Minitest::Test
     end
     task.define_singleton_method(:sysecho) { |*_args, **_kwargs| true }
     task.define_singleton_method(:validate_version_match!) { |*_args, **_kwargs| true }
-    task.define_singleton_method(:validate_release_commit!) { |*_args, **_kwargs| true }
-    task.define_singleton_method(:existing_pr_number) { |*_args| nil }
+    task.define_singleton_method(:find_release_commit!) { |*_args, **_kwargs| FAKE_RELEASE_SHA }
     task.define_singleton_method(:pr_already_merged?) { |_ref| false }
 
     task
@@ -252,41 +303,25 @@ class DischargerReleaseCommandSequenceTest < Minitest::Test
       "Should fetch staging and production branches"
   end
 
-  def test_auto_deploy_mode_creates_pr_then_merges_working_branch
+  def test_auto_deploy_mode_tags_release_commit_directly
     task = build_task(:rel_auto_seq, auto_deploy: true)
     task.define
     $stdin = StringIO.new("\n")
 
     capture_io { Rake::Task["rel_auto_seq"].invoke }
 
-    assert command_issued?(/gh pr create --base main --head develop/),
-      "Auto-deploy should create PR from working branch to production"
-    assert command_issued?("gh pr merge develop --merge"),
-      "Auto-deploy should merge working branch (not staging)"
-    assert command_issued?(/git tag -a v1\.2\.3 .+ main/),
-      "Should tag production branch"
+    refute command_issued?(/gh pr create/),
+      "Auto-deploy should not create a production PR"
+    refute command_issued?(/gh pr merge/),
+      "Auto-deploy should not merge a PR"
+    assert command_issued?("git tag -a v1.2.3 -m 'Release 1.2.3' #{FAKE_RELEASE_SHA}"),
+      "Should tag the changelog finalize commit"
     assert command_issued?("git push origin v1.2.3"),
       "Should push the tag"
-    assert command_issued?("git fetch origin main:main develop"),
-      "Should fetch production branch and working branch tracking ref"
+    assert command_issued?("git fetch origin develop"),
+      "Should fetch the working branch"
     assert command_issued?("git reset --hard origin/develop"),
       "Should reset working branch to match remote"
-  end
-
-  def test_auto_deploy_mode_pr_create_precedes_merge
-    task = build_task(:rel_order_seq, auto_deploy: true)
-    task.define
-    $stdin = StringIO.new("\n")
-
-    capture_io { Rake::Task["rel_order_seq"].invoke }
-
-    create_idx = @commands.index { |c| c.join(" ").match?(/gh pr create/) }
-    merge_idx = @commands.index { |c| c.join(" ").match?(/gh pr merge/) }
-
-    assert create_idx, "Expected gh pr create command"
-    assert merge_idx, "Expected gh pr merge command"
-    assert_operator create_idx, :<, merge_idx,
-      "PR create must precede PR merge"
   end
 
   def test_standard_mode_skips_merge_when_pr_already_merged
@@ -303,20 +338,6 @@ class DischargerReleaseCommandSequenceTest < Minitest::Test
       "Should still tag production branch"
     assert command_issued?("git push origin v1.2.3"),
       "Should still push the tag"
-  end
-
-  def test_auto_deploy_mode_reuses_existing_pr
-    task = build_task(:rel_reuse_seq, auto_deploy: true)
-    task.define_singleton_method(:existing_pr_number) { |*_args| "42" }
-    task.define
-    $stdin = StringIO.new("\n")
-
-    capture_io { Rake::Task["rel_reuse_seq"].invoke }
-
-    refute command_issued?(/gh pr create/),
-      "Should not create a PR when one already exists"
-    assert command_issued?("gh pr merge 42 --merge"),
-      "Should merge by PR number when reusing an existing PR"
   end
 end
 
@@ -541,9 +562,9 @@ class DischargerReleaseThreadTest < Minitest::Test
     end
     task.define_singleton_method(:sysecho) { |*_args, **_kwargs| true }
     task.define_singleton_method(:validate_version_match!) { |*_args, **_kwargs| true }
-    task.define_singleton_method(:validate_release_commit!) { |*_args, **_kwargs| true }
-    task.define_singleton_method(:existing_pr_number) { |*_args| nil }
     task.define_singleton_method(:pr_already_merged?) { |_ref| false }
+    changelog_text = File.read(@changelog_path)
+    task.define_singleton_method(:git_show_at_commit) { |_sha, _path| changelog_text }
     task.define_singleton_method(:runbook_items) { runbook_items || [] }
 
     task


### PR DESCRIPTION
Skedify's releases under auto_deploy_staging hit two failures. The 2026.6.A release shipped an empty changelog with no archive file: retain_changelogs was never forwarded to Reissue, and prepare had cut the finish branch from a stale local develop. The 2026.7.A release would have been blocked outright: the release gate required HEAD to be the finalize commit, and another PR merged into develop between finalize and release.

Each commit fixes one of those or was asked for directly. retain_changelogs now reaches Reissue so finalize writes the archive. Auto-deploy releases locate the commit that finalized the changelog for the current version and tag exactly that, with no production PR; Slack reports the tagged SHA and posts the changelog as it exists at the tag. prepare fetches, refuses unpushed local commits, and resets to origin before cutting the finish branch. An optional pr_label creates the finalize and bump PRs through gh with the label attached — Skedify sets no-changelog-needed so Danger stops blocking release PRs — and reuses an existing PR on re-runs; without pr_label the compare-URL flow is unchanged.

The traditional staging flow is untouched.

The tag-the-finalize-commit flow ran the real Skedify 2026.7.A release end to end on 2026-07-22.
