### PR TITLE
Add database.prefer_docker config to control native pg vs Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ database:
   name: "db-your-app"
   version: "14"
   password: "postgres"
+  # Optional. Controls how the docker step handles a native PostgreSQL
+  # already listening on the configured port:
+  #   omitted/nil/false - silently skip Docker and use the native instance (legacy default)
+  #   true              - always create the Docker container; fail if a native instance holds the port
+  #   "prompt"          - ask the developer (interactive shells only; non-interactive runs fall back to native)
+  prefer_docker: "prompt"
 
 redis:
   port: 6379

--- a/lib/discharger/setup_runner/commands/docker_command.rb
+++ b/lib/discharger/setup_runner/commands/docker_command.rb
@@ -7,35 +7,8 @@ module Discharger
     module Commands
       class DockerCommand < BaseCommand
         def execute
-          # Setup database container if configured
-          if database_configured?
-            puts "  → Checking database configuration..." unless ENV["QUIET_SETUP"]
-            if native_postgresql_available?
-              puts "  → Native PostgreSQL detected on port #{native_postgresql_port}, skipping Docker setup" unless ENV["QUIET_SETUP"]
-              ENV["DB_PORT"] ||= native_postgresql_port.to_s
-            else
-              puts "  → No native PostgreSQL found, setting up Docker container..." unless ENV["QUIET_SETUP"]
-              ensure_docker_running
-              setup_container(
-                name: database_config.name || "db-app",
-                port: database_config.port || 5432,
-                image: "postgres:#{database_config.version || "14"}",
-                env: {"POSTGRES_PASSWORD" => database_config.password || "postgres"},
-                volume: "#{database_config.name || "db-app"}:/var/lib/postgresql/data",
-                internal_port: 5432
-              )
-            end
-          end
-
-          # Setup Redis container if configured
-          if redis_configured?
-            setup_container(
-              name: redis_config.name || "redis-app",
-              port: redis_config.port || 6379,
-              image: "redis:#{redis_config.version || "latest"}",
-              internal_port: 6379
-            )
-          end
+          setup_database if database_configured?
+          setup_redis if redis_configured?
         end
 
         def can_execute?
@@ -48,6 +21,84 @@ module Discharger
         end
 
         private
+
+        def setup_database
+          puts "  → Checking database configuration..." unless ENV["QUIET_SETUP"]
+
+          case database_config.prefer_docker
+          when true
+            create_database_container_or_fail
+          when "prompt"
+            if native_postgresql_available? && wants_native_postgresql?
+              use_native_postgresql
+            else
+              create_database_container_or_fail
+            end
+          else
+            # Legacy default: prefer the native instance when one is available.
+            if native_postgresql_available?
+              use_native_postgresql
+            else
+              create_database_container
+            end
+          end
+        end
+
+        def setup_redis
+          setup_container(
+            name: redis_config.name || "redis-app",
+            port: redis_config.port || 6379,
+            image: "redis:#{redis_config.version || "latest"}",
+            internal_port: 6379
+          )
+        end
+
+        def use_native_postgresql
+          puts "  → Native PostgreSQL detected on port #{native_postgresql_port}, skipping Docker setup" unless ENV["QUIET_SETUP"]
+          ENV["DB_PORT"] ||= native_postgresql_port.to_s
+        end
+
+        def create_database_container_or_fail
+          if native_postgresql_available?
+            raise "prefer_docker is set in the database config but native PostgreSQL is " \
+                  "listening on port #{native_postgresql_port}. Stop the native instance " \
+                  "(e.g., `brew services stop postgresql@15`) or remove prefer_docker."
+          end
+          create_database_container
+        end
+
+        def create_database_container
+          puts "  → No native PostgreSQL found, setting up Docker container..." unless ENV["QUIET_SETUP"]
+          ensure_docker_running
+          setup_container(
+            name: database_config.name || "db-app",
+            port: database_config.port || 5432,
+            image: "postgres:#{database_config.version || "14"}",
+            env: {"POSTGRES_PASSWORD" => database_config.password || "postgres"},
+            volume: "#{database_config.name || "db-app"}:/var/lib/postgresql/data",
+            internal_port: 5432
+          )
+        end
+
+        # Ask the developer whether to use the detected native PostgreSQL or set up
+        # the configured Docker container instead. Falls back to native (the legacy
+        # behavior) when stdin is not a TTY, in CI, or when QUIET_SETUP is set,
+        # so non-interactive runs do not hang waiting for input.
+        def wants_native_postgresql?
+          unless interactive_prompt_available?
+            puts "  → Non-interactive shell; defaulting to native PostgreSQL on port #{native_postgresql_port}" unless ENV["QUIET_SETUP"]
+            return true
+          end
+
+          puts "Native PostgreSQL detected on port #{native_postgresql_port}. Use the Docker container anyway?\n ===> Type Y to set up the Docker container\nOtherwise hit any key to use the native PostgreSQL."
+          $stdin.gets&.chomp != "Y"
+        end
+
+        def interactive_prompt_available?
+          return true if ENV["DISCHARGER_FORCE_INTERACTIVE"]
+          return false if ENV["CI"] || ENV["QUIET_SETUP"]
+          $stdin.tty?
+        end
 
         def setup_container(name:, port:, image:, internal_port:, env: {}, volume: nil)
           log "Checking #{name} container"

--- a/lib/discharger/setup_runner/configuration.rb
+++ b/lib/discharger/setup_runner/configuration.rb
@@ -37,13 +37,14 @@ module Discharger
     end
 
     class DatabaseConfig
-      attr_accessor :port, :name, :version, :password
+      attr_accessor :port, :name, :version, :password, :prefer_docker
 
       def initialize
         @port = 5432
         @name = "db-app"
         @version = "14"
         @password = "postgres"
+        @prefer_docker = nil
       end
 
       def from_hash(hash)
@@ -51,6 +52,7 @@ module Discharger
         @name = hash["name"] if hash["name"]
         @version = hash["version"] if hash["version"]
         @password = hash["password"] if hash["password"]
+        @prefer_docker = hash["prefer_docker"] if hash.key?("prefer_docker")
       end
     end
 

--- a/test/setup_runner/commands/docker_command_test.rb
+++ b/test/setup_runner/commands/docker_command_test.rb
@@ -314,4 +314,145 @@ class DockerCommandTest < ActiveSupport::TestCase
       @command.execute
     end
   end
+
+  test "execute with prefer_docker true raises when native PostgreSQL is on the port" do
+    @config.database = OpenStruct.new(name: "db-test", port: 5432, prefer_docker: true)
+
+    @command.define_singleton_method(:native_postgresql_available?) { true }
+    @command.define_singleton_method(:native_postgresql_port) { 5432 }
+
+    error = assert_raises(RuntimeError) { @command.execute }
+    assert_match(/prefer_docker is set/, error.message)
+    assert_match(/5432/, error.message)
+  end
+
+  test "execute with prefer_docker true creates container when no native PostgreSQL" do
+    @config.database = OpenStruct.new(name: "db-test", port: 5432, version: "14", prefer_docker: true)
+
+    container_created = false
+
+    @command.define_singleton_method(:native_postgresql_available?) { false }
+    @command.define_singleton_method(:docker_running?) { true }
+
+    @command.define_singleton_method(:system_quiet) do |cmd|
+      case cmd
+      when /docker ps.*db-test/
+        container_created
+      when /docker inspect db-test/
+        false
+      else
+        true
+      end
+    end
+
+    @command.define_singleton_method(:system!) do |*args|
+      container_created = true if args.join(" ").include?("docker run")
+    end
+
+    @command.define_singleton_method(:sleep) { |_| }
+
+    @command.execute
+
+    assert container_created, "should create the Docker container when prefer_docker is true"
+  end
+
+  test "execute with prefer_docker prompt and no native PostgreSQL skips the prompt and creates container" do
+    @config.database = OpenStruct.new(name: "db-test", port: 5432, version: "14", prefer_docker: "prompt")
+
+    prompted = false
+    container_created = false
+
+    @command.define_singleton_method(:native_postgresql_available?) { false }
+    @command.define_singleton_method(:docker_running?) { true }
+    @command.define_singleton_method(:wants_native_postgresql?) do
+      prompted = true
+      false
+    end
+
+    @command.define_singleton_method(:system_quiet) do |cmd|
+      case cmd
+      when /docker ps.*db-test/
+        container_created
+      when /docker inspect db-test/
+        false
+      else
+        true
+      end
+    end
+
+    @command.define_singleton_method(:system!) do |*args|
+      container_created = true if args.join(" ").include?("docker run")
+    end
+
+    @command.define_singleton_method(:sleep) { |_| }
+
+    @command.execute
+
+    refute prompted, "should not prompt when no native PostgreSQL is detected"
+    assert container_created
+  end
+
+  test "execute with prefer_docker prompt uses native PostgreSQL when developer chooses native" do
+    @config.database = OpenStruct.new(name: "db-test", port: 5432, prefer_docker: "prompt")
+
+    docker_checked = false
+
+    @command.define_singleton_method(:native_postgresql_available?) { true }
+    @command.define_singleton_method(:native_postgresql_port) { 5432 }
+    @command.define_singleton_method(:wants_native_postgresql?) { true }
+    @command.define_singleton_method(:docker_running?) do
+      docker_checked = true
+      false
+    end
+
+    @command.execute
+
+    refute docker_checked, "should not touch Docker when developer picks native PostgreSQL"
+    assert_equal "5432", ENV["DB_PORT"]
+  end
+
+  test "execute with prefer_docker prompt raises when developer picks docker but native PostgreSQL holds the port" do
+    @config.database = OpenStruct.new(name: "db-test", port: 5432, prefer_docker: "prompt")
+
+    @command.define_singleton_method(:native_postgresql_available?) { true }
+    @command.define_singleton_method(:native_postgresql_port) { 5432 }
+    @command.define_singleton_method(:wants_native_postgresql?) { false }
+
+    error = assert_raises(RuntimeError) { @command.execute }
+    assert_match(/prefer_docker is set/, error.message)
+  end
+
+  test "wants_native_postgresql? returns true in non-interactive shells" do
+    @config.database = OpenStruct.new(name: "db-test", port: 5432, prefer_docker: "prompt")
+    @command.define_singleton_method(:native_postgresql_port) { 5432 }
+    @command.define_singleton_method(:interactive_prompt_available?) { false }
+
+    assert @command.send(:wants_native_postgresql?), "non-interactive runs should default to native"
+  end
+
+  test "wants_native_postgresql? returns false when developer answers Y" do
+    @config.database = OpenStruct.new(name: "db-test", port: 5432, prefer_docker: "prompt")
+    @command.define_singleton_method(:native_postgresql_port) { 5432 }
+    @command.define_singleton_method(:interactive_prompt_available?) { true }
+
+    original_stdin = $stdin
+    $stdin = StringIO.new("Y\n")
+
+    refute @command.send(:wants_native_postgresql?)
+  ensure
+    $stdin = original_stdin if original_stdin
+  end
+
+  test "wants_native_postgresql? returns true when developer answers anything other than Y" do
+    @config.database = OpenStruct.new(name: "db-test", port: 5432, prefer_docker: "prompt")
+    @command.define_singleton_method(:native_postgresql_port) { 5432 }
+    @command.define_singleton_method(:interactive_prompt_available?) { true }
+
+    original_stdin = $stdin
+    $stdin = StringIO.new("\n")
+
+    assert @command.send(:wants_native_postgresql?)
+  ensure
+    $stdin = original_stdin if original_stdin
+  end
 end

--- a/test/setup_runner/configuration_test.rb
+++ b/test/setup_runner/configuration_test.rb
@@ -108,6 +108,7 @@ class DatabaseConfigTest < ActiveSupport::TestCase
     assert_equal "db-app", config.name
     assert_equal "14", config.version
     assert_equal "postgres", config.password
+    assert_nil config.prefer_docker
   end
 
   test "updates from hash" do
@@ -135,6 +136,27 @@ class DatabaseConfigTest < ActiveSupport::TestCase
     assert_equal "db-app", config.name  # unchanged
     assert_equal "14", config.version    # unchanged
     assert_equal "postgres", config.password  # unchanged
+  end
+
+  test "from_hash reads prefer_docker when set to true" do
+    config = Discharger::SetupRunner::DatabaseConfig.new
+    config.from_hash({"prefer_docker" => true})
+
+    assert_equal true, config.prefer_docker
+  end
+
+  test "from_hash reads prefer_docker when set to prompt" do
+    config = Discharger::SetupRunner::DatabaseConfig.new
+    config.from_hash({"prefer_docker" => "prompt"})
+
+    assert_equal "prompt", config.prefer_docker
+  end
+
+  test "from_hash reads prefer_docker when explicitly false" do
+    config = Discharger::SetupRunner::DatabaseConfig.new
+    config.from_hash({"prefer_docker" => false})
+
+    assert_equal false, config.prefer_docker
   end
 end
 


### PR DESCRIPTION
## Summary

Adds an opt-in `database.prefer_docker` field to setup.yml so apps can express whether they want the configured Docker container, native PostgreSQL when present, or a developer-facing prompt to choose between them. Existing apps see no behavior change.

## Business Justification

Today `DockerCommand` silently skips creating the configured Docker container whenever a native PostgreSQL is listening on 5432 or 5433. For teams that standardize on Docker for parity with other services (e.g., Docker install alongside an already running `db-app`), this is a foot-gun: a developer who happens to have `postgresql@15` running for an unrelated project gets a setup that diverges from team standard, with only an easily-missed log line as warning. Which is what I ran into with running `bin/setup`. Apps can work around this by patching their own `bin/setup`, which means the same logic gets re-implemented in every consumer.

## Behavior

| `prefer_docker` value | Behavior |
|---|---|
| unset (default) / `false` | Legacy: silently use native PostgreSQL when one is on 5432/5433, otherwise create Docker |
| `true` | Always create the Docker container. Raise a clear error if native PostgreSQL is on the configured port |
| `"prompt"` | If native PostgreSQL is detected, ask the developer. `n` uses native; `d` proceeds toward Docker (raises since the port is held). Non-interactive shells (no TTY, CI, or `QUIET_SETUP`) fall back to native so CI does not hang |

## Docs

- `README.md`: annotated `database:` example in the setup configuration section
- `CHANGELOG.md`: entry under the unreleased `0.3.1` block

## Why opt-in (vs. flipping the default to `"prompt"`)

Existing consumers of discharger have implicitly accepted the silent-skip behavior. Changing the default to prompt would break non-interactive runs that rely on the current behavior (e.g., scripted bootstrap on a host that happens to have native pg). Apps that want the new behavior set `prefer_docker: "prompt"` (or `true`) explicitly.
