### PR TITLE
fix(setup): reshim asdf after corepack enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.3.1] - Unreleased
 
+### Fixed
+
+- Reshim asdf after `corepack enable` so `yarn install` succeeds without manual `asdf reshim nodejs` when nodejs is asdf-managed
+
 ## [0.2.31] - 2026-04-09
 
 ### Added

--- a/lib/discharger/setup_runner/commands/yarn_command.rb
+++ b/lib/discharger/setup_runner/commands/yarn_command.rb
@@ -14,6 +14,14 @@ module Discharger
             if system_quiet("which corepack")
               system! "corepack enable"
 
+              # corepack enable drops yarn into the active nodejs install. When asdf
+              # manages nodejs, the existing yarn shim caches which nodejs versions
+              # provide yarn and won't see the new one until shims are regenerated.
+              if system_quiet("which asdf")
+                log "Refreshing asdf shims after corepack enable"
+                system_quiet "asdf reshim nodejs"
+              end
+
               package_json_path = File.join(app_root, "package.json")
               if File.exist?(package_json_path)
                 begin

--- a/test/setup_runner/commands/yarn_command_test.rb
+++ b/test/setup_runner/commands/yarn_command_test.rb
@@ -54,6 +54,69 @@ class YarnCommandTest < ActiveSupport::TestCase
     assert_includes commands_run, "yarn install"
   end
 
+  test "execute reshims asdf after corepack enable when asdf is installed" do
+    create_file("package.json", '{"name": "test-app"}')
+    create_file("yarn.lock", "# yarn lockfile v1")
+
+    quiet_commands = []
+    bang_commands = []
+
+    @command.define_singleton_method(:system_quiet) do |cmd|
+      quiet_commands << cmd
+      case cmd
+      when "which corepack", "which asdf"
+        true
+      when "yarn check --check-files > /dev/null 2>&1"
+        false
+      else
+        true
+      end
+    end
+
+    @command.define_singleton_method(:system!) do |*args|
+      bang_commands << args.join(" ")
+    end
+
+    @command.execute
+
+    assert_includes bang_commands, "corepack enable"
+    assert_includes quiet_commands, "asdf reshim nodejs"
+    asdf_check_index = quiet_commands.index("which asdf")
+    reshim_index = quiet_commands.index("asdf reshim nodejs")
+    assert asdf_check_index < reshim_index, "which asdf must precede asdf reshim nodejs"
+  end
+
+  test "execute skips asdf reshim when asdf is not installed" do
+    create_file("package.json", '{"name": "test-app"}')
+    create_file("yarn.lock", "# yarn lockfile v1")
+
+    quiet_commands = []
+    bang_commands = []
+
+    @command.define_singleton_method(:system_quiet) do |cmd|
+      quiet_commands << cmd
+      case cmd
+      when "which corepack"
+        true
+      when "which asdf"
+        false
+      when "yarn check --check-files > /dev/null 2>&1"
+        false
+      else
+        true
+      end
+    end
+
+    @command.define_singleton_method(:system!) do |*args|
+      bang_commands << args.join(" ")
+    end
+
+    @command.execute
+
+    assert_includes bang_commands, "corepack enable"
+    refute_includes quiet_commands, "asdf reshim nodejs"
+  end
+
   test "execute skips yarn install when yarn check succeeds" do
     create_file("package.json", '{"name": "test-app"}')
     create_file("yarn.lock", "# yarn lockfile v1")


### PR DESCRIPTION
## Summary

When asdf manages nodejs, `bin/setup` failed at `yarn install` because `corepack enable` placed yarn into the active nodejs install but the existing asdf yarn shim cached its providing-versions list and did not yet list that nodejs version. Running `asdf reshim nodejs` after `corepack enable` fixes it; this PR automates the reshim inside `YarnCommand`.

## Changes

- `lib/discharger/setup_runner/commands/yarn_command.rb`: run `asdf reshim nodejs` after `corepack enable` whenever `which asdf` succeeds. Gated symmetrically to `AsdfCommand`; the reshim itself uses `system_quiet` so a host with asdf but no nodejs plugin will not blow up setup.
- `test/setup_runner/commands/yarn_command_test.rb`: two new cases covering both branches of the asdf check (reshim runs when `which asdf` succeeds; reshim is skipped when it fails).
- `CHANGELOG.md`: `Fixed` entry under `[0.3.1] - Unreleased`.

<details>
<summary>Full description</summary>

## Summary

When asdf manages nodejs and `bin/setup` runs `corepack enable` to provision yarn, the next yarn invocation fails with a stale-shim error until `asdf reshim nodejs` runs. This fix runs the reshim automatically inside `YarnCommand` whenever asdf is on PATH.

## Repro

On a host where asdf manages nodejs (e.g. nodejs 24.11.1 in `.tool-versions`), corepack happily creates `~/.asdf/installs/nodejs/24.11.1/bin/yarn`, but the asdf yarn shim still carries metadata from a previous reshim and does not list the new nodejs version as a provider. The next `yarn --version` (and therefore `yarn install` later in setup) errors with:

```
No version is set for command yarn
Consider adding one of the following versions in your config file at .tool-versions
nodejs 22.18.0
nodejs 22.17.0
...
```

Running `asdf reshim nodejs` after `corepack enable` regenerates the shim metadata and yarn (4.9.2 in qualify's case) resolves correctly. The fix automates that step.

## Change

`YarnCommand#execute` now runs `asdf reshim nodejs` immediately after `corepack enable` whenever `which asdf` succeeds. The check is gated on `which asdf`, mirroring how `AsdfCommand` already gates itself, so it is a no-op when asdf is not installed. The reshim itself uses `system_quiet`, so a host with asdf but without the nodejs plugin will not blow up setup.

## Verification

- `bundle exec rake test` passes (263 runs, 621 assertions, 0 failures), including two new `YarnCommandTest` cases that cover both branches: reshim runs when `which asdf` succeeds, and is skipped when it fails.
- Built `discharger-0.3.1.gem` from this branch and drove the patched `YarnCommand` directly against `~/code/sofware/qualify` (which pins nodejs 24.11.1 in `.tool-versions`). The new "Refreshing asdf shims after corepack enable" log fires, `asdf reshim nodejs` runs, and yarn 4.9.2 then resolves and completes the install end-to-end.

## Out of scope

- No `bin/setup` regeneration; the `lib/generators/discharger/install/templates/setup` template is unchanged. Qualify's customized `bin/setup` stays byte-identical.
- No version bump (handled by `reissue` workflow).

</details>