### PR TITLE
Make pg_tools setup opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.3.2] - Unreleased
 
+### Changed
+
+- Treat generated pg_tools setup as opt-in for apps that use structure.sql or PostgreSQL CLI workflows.
+
 ## [0.3.1] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -199,12 +199,12 @@ The `pre_steps` array defines commands that run **before Rails loads**. These ar
 
 Built-in pre_steps:
 - `homebrew` - Installs Homebrew if not present (macOS)
-- `postgresql_tools` - Installs PostgreSQL client tools (`pg_dump`, `psql`)
+- `postgresql_tools` - Optionally installs PostgreSQL client tools (`pg_dump`, `psql`) for apps that use `structure.sql` or call those tools directly
 
 ```yaml
 pre_steps:
   - homebrew
-  - postgresql_tools
+  # - postgresql_tools
 ```
 
 You can also define custom pre_steps with shell commands:
@@ -228,6 +228,7 @@ The `steps` array specifies which built-in setup commands to run. Available comm
 - `yarn` - Install JavaScript packages
 - `config` - Copy configuration files
 - `docker` - Setup Docker containers
+- `pg_tools` - Create Docker-aware `pg_dump` and `psql` wrappers for apps that use `structure.sql` or call those tools directly
 - `env` - Configure environment variables
 - `database` - Setup and migrate database
 

--- a/lib/discharger/setup_runner/prerequisites_loader.rb
+++ b/lib/discharger/setup_runner/prerequisites_loader.rb
@@ -55,12 +55,34 @@ module Discharger
       def set_db_port(db_config)
         if db_config["port"] && !ENV["DB_PORT"]
           ENV["DB_PORT"] = db_config["port"].to_s
-          ENV["PGPORT"] = db_config["port"].to_s
+          set_pgport_if_needed(db_config["port"].to_s)
           puts "  Setting DB_PORT=#{db_config["port"]} from config/setup.yml"
         elsif ENV["DB_PORT"]
           warn_if_mismatch("DB_PORT", ENV["DB_PORT"], db_config["port"].to_s)
-          ENV["PGPORT"] = ENV["DB_PORT"]
+          set_pgport_if_needed(ENV["DB_PORT"])
         end
+      end
+
+      def set_pgport_if_needed(port)
+        ENV["PGPORT"] = port if postgresql_cli_setup_enabled?
+      end
+
+      def postgresql_cli_setup_enabled?
+        configured_pre_steps.include?("postgresql_tools") ||
+          configured_steps.include?("pg_tools") ||
+          all_regular_steps_enabled?
+      end
+
+      def configured_pre_steps
+        Array(config["pre_steps"]).select { |step| step.is_a?(String) }
+      end
+
+      def configured_steps
+        Array(config["steps"]).select { |step| step.is_a?(String) }
+      end
+
+      def all_regular_steps_enabled?
+        !config.key?("steps") || Array(config["steps"]).empty?
       end
 
       def set_db_name(db_config)

--- a/lib/generators/discharger/install/templates/setup.yml
+++ b/lib/generators/discharger/install/templates/setup.yml
@@ -24,7 +24,7 @@ redis:
 #
 # Built-in pre_steps:
 #   - homebrew         # Installs Homebrew if not present
-#   - postgresql_tools # Installs PostgreSQL client tools (pg_dump, psql)
+#   - postgresql_tools # Optional: installs PostgreSQL client tools for structure.sql workflows
 #
 # Custom pre_steps (run shell commands):
 #   - description: "Description of step"
@@ -33,7 +33,7 @@ redis:
 #
 pre_steps: []
   # - homebrew
-  # - postgresql_tools
+  # - postgresql_tools # Optional: for apps that use structure.sql or pg_dump/psql directly
 
 # Built-in commands to run (empty array runs all available commands)
 # Available commands: brew, asdf, git, bundler, yarn, config, docker, pg_tools, env, database
@@ -45,9 +45,11 @@ steps:
   - yarn
   - config
   - docker
-  - pg_tools
   - env
   - database
+
+# Optional for apps that use structure.sql or other pg_dump/psql workflows:
+#   - pg_tools
 
 # Custom commands for application-specific setup (run AFTER Rails loads)
 custom_steps:

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -44,6 +44,8 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     assert_file "config/setup.yml" do |content|
       assert_match(/app_name:/, content)
       assert_match(/steps:/, content)
+      refute_match(/^\s+- pg_tools$/, content)
+      assert_match(/structure\.sql/, content)
     end
   end
 

--- a/test/setup_runner/prerequisites_loader_test.rb
+++ b/test/setup_runner/prerequisites_loader_test.rb
@@ -24,6 +24,79 @@ class PrerequisitesLoaderTest < ActiveSupport::TestCase
     yaml_content = <<~YAML
       database:
         port: 5433
+      steps:
+        - pg_tools
+    YAML
+    create_file("setup.yml", yaml_content)
+
+    original_db_port = ENV["DB_PORT"]
+    original_pgport = ENV["PGPORT"]
+    ENV.delete("DB_PORT")
+    ENV.delete("PGPORT")
+
+    begin
+      loader = Discharger::SetupRunner::PrerequisitesLoader.new("setup.yml")
+      capture_io { loader.run }
+
+      assert_equal "5433", ENV["DB_PORT"]
+      assert_equal "5433", ENV["PGPORT"]
+    ensure
+      if original_db_port
+        ENV["DB_PORT"] = original_db_port
+      else
+        ENV.delete("DB_PORT")
+      end
+      if original_pgport
+        ENV["PGPORT"] = original_pgport
+      else
+        ENV.delete("PGPORT")
+      end
+    end
+  end
+
+  test "does not set PGPORT when PostgreSQL CLI setup is not enabled" do
+    yaml_content = <<~YAML
+      database:
+        port: 5433
+      steps:
+        - docker
+        - database
+    YAML
+    create_file("setup.yml", yaml_content)
+
+    original_db_port = ENV["DB_PORT"]
+    original_pgport = ENV["PGPORT"]
+    ENV.delete("DB_PORT")
+    ENV.delete("PGPORT")
+
+    begin
+      loader = Discharger::SetupRunner::PrerequisitesLoader.new("setup.yml")
+      capture_io { loader.run }
+
+      assert_equal "5433", ENV["DB_PORT"]
+      assert_nil ENV["PGPORT"]
+    ensure
+      if original_db_port
+        ENV["DB_PORT"] = original_db_port
+      else
+        ENV.delete("DB_PORT")
+      end
+      if original_pgport
+        ENV["PGPORT"] = original_pgport
+      else
+        ENV.delete("PGPORT")
+      end
+    end
+  end
+
+  test "sets PGPORT when pg_tools step is enabled" do
+    yaml_content = <<~YAML
+      database:
+        port: 5433
+      steps:
+        - docker
+        - pg_tools
+        - database
     YAML
     create_file("setup.yml", yaml_content)
 


### PR DESCRIPTION
## Summary

- Stop scaffolding `pg_tools` as a default setup step
- Document `pg_tools` and `postgresql_tools` as opt-in for `structure.sql` or direct PostgreSQL CLI workflows
- Only set `PGPORT` during prerequisites when PostgreSQL CLI setup is enabled
- Add generator and prerequisite coverage for the new defaults

## Verification

- `bundle exec ruby -Itest test/setup_runner/prerequisites_loader_test.rb test/generators/install_generator_test.rb`
- `XDG_CACHE_HOME=/tmp bundle exec standardrb`
- `bundle exec rake test`
- `git diff --check`
