### PR TITLE
Retry brew bundle once on transient setup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Treat generated pg_tools setup as opt-in for apps that use structure.sql or PostgreSQL CLI workflows.
 
+### Fixed
+
+- Retry `brew bundle` once before failing setup, so transient Homebrew lock contention (e.g. two `bin/setup` runs on the same host) doesn't hard-fail the whole run.
+
 ## [0.3.1] - 2026-05-13
 
 ### Added

--- a/lib/discharger/setup_runner/commands/brew_command.rb
+++ b/lib/discharger/setup_runner/commands/brew_command.rb
@@ -6,10 +6,12 @@ module Discharger
   module SetupRunner
     module Commands
       class BrewCommand < BaseCommand
+        RETRY_DELAY_SECONDS = 2
+
         def execute
           proceed_with "brew bundle" do
             log "Ensuring brew dependencies"
-            system! "brew bundle"
+            run_brew_bundle
           end
         end
 
@@ -19,6 +21,23 @@ module Discharger
 
         def description
           "Install Homebrew dependencies"
+        end
+
+        private
+
+        # brew bundle can fail transiently (e.g. Homebrew lock contention from a
+        # concurrent `brew` invocation) unrelated to the app's actual dependencies.
+        # Retry once before treating it as a real setup failure.
+        def run_brew_bundle
+          system! "brew bundle"
+        rescue => e
+          log "brew bundle failed, retrying once: #{e.message}"
+          sleep retry_delay
+          system! "brew bundle"
+        end
+
+        def retry_delay
+          RETRY_DELAY_SECONDS
         end
       end
     end

--- a/test/setup_runner/commands/brew_command_test.rb
+++ b/test/setup_runner/commands/brew_command_test.rb
@@ -95,6 +95,7 @@ class BrewCommandTest < ActiveSupport::TestCase
     # Mock user input and failing system call
     input = StringIO.new("Y\n")
     @command.define_singleton_method(:gets) { input.gets }
+    @command.define_singleton_method(:retry_delay) { 0 }
     @command.define_singleton_method(:system!) do |*args|
       raise "brew bundle failed:"
     end
@@ -104,5 +105,49 @@ class BrewCommandTest < ActiveSupport::TestCase
         @command.execute
       end
     end
+  end
+
+  test "execute retries once after a transient brew bundle failure and succeeds" do
+    create_file("Brewfile", "brew 'git'")
+
+    input = StringIO.new("Y\n")
+    @command.define_singleton_method(:gets) { input.gets }
+    @command.define_singleton_method(:retry_delay) { 0 }
+
+    call_count = 0
+    @command.define_singleton_method(:system!) do |*args|
+      call_count += 1
+      raise "brew bundle failed: lock contention" if call_count == 1
+    end
+
+    with_tty_stdin do
+      with_output_enabled do
+        capture_output { @command.execute }
+      end
+    end
+
+    assert_equal 2, call_count
+  end
+
+  test "execute does not retry a second time after two consecutive failures" do
+    create_file("Brewfile", "brew 'git'")
+
+    input = StringIO.new("Y\n")
+    @command.define_singleton_method(:gets) { input.gets }
+    @command.define_singleton_method(:retry_delay) { 0 }
+
+    call_count = 0
+    @command.define_singleton_method(:system!) do |*args|
+      call_count += 1
+      raise "brew bundle failed: still broken"
+    end
+
+    assert_raises(RuntimeError) do
+      capture_output do
+        @command.execute
+      end
+    end
+
+    assert_equal 2, call_count
   end
 end


### PR DESCRIPTION
`brew bundle` hard-fails the entire `bin/setup` on any nonzero exit — including transient ones. Observed: two concurrent `bin/setup` runs died on Homebrew lock contention; retried sequentially, both succeeded. This retries once after 2s, then fails for real.

- Rescues `StandardError` — no narrower class exists (`system!` raises plain `RuntimeError` strings). Can't mask real failures: attempt two is unrescued, so a broken Brewfile still surfaces with its own backtrace
- Retry-once over warn-and-continue: continuing past a real dependency failure would fake a successful setup
- `retry_delay` is stubbable (2s prod / 0 in tests), matching the file's existing mock style
- Tests pin the exact contract: two attempts then success; two attempts then raise — never a third
- CHANGELOG entry under existing `[0.3.2] - Unreleased`