### PR TITLE
Stop forwarding localhost host/port flags into docker exec

### DIFF
--- a/lib/discharger/setup_runner/commands/pg_tools_command.rb
+++ b/lib/discharger/setup_runner/commands/pg_tools_command.rb
@@ -85,6 +85,10 @@ module Discharger
                     shift
                     ;;
                   -h|--host)
+                    if [[ $# -lt 2 ]]; then
+                      echo "Error: $1 requires an argument" >&2
+                      exit 2
+                    fi
                     HOST="$2"
                     shift 2
                     ;;
@@ -97,6 +101,10 @@ module Discharger
                     shift
                     ;;
                   -p|--port)
+                    if [[ $# -lt 2 ]]; then
+                      echo "Error: $1 requires an argument" >&2
+                      exit 2
+                    fi
                     PORT="$2"
                     shift 2
                     ;;
@@ -195,6 +203,10 @@ module Discharger
                     shift
                     ;;
                   -h|--host)
+                    if [[ $# -lt 2 ]]; then
+                      echo "Error: $1 requires an argument" >&2
+                      exit 2
+                    fi
                     HOST="$2"
                     shift 2
                     ;;
@@ -207,6 +219,10 @@ module Discharger
                     shift
                     ;;
                   -p|--port)
+                    if [[ $# -lt 2 ]]; then
+                      echo "Error: $1 requires an argument" >&2
+                      exit 2
+                    fi
                     PORT="$2"
                     shift 2
                     ;;

--- a/lib/discharger/setup_runner/commands/pg_tools_command.rb
+++ b/lib/discharger/setup_runner/commands/pg_tools_command.rb
@@ -62,6 +62,8 @@ module Discharger
               # When running in Docker, we need to output to stdout and redirect locally
               OUTPUT_FILE=""
               HAS_USER=""
+              HOST=""
+              PORT=""
               ARGS=()
               while [[ $# -gt 0 ]]; do
                 case $1 in
@@ -82,6 +84,30 @@ module Discharger
                     ARGS+=("$1")
                     shift
                     ;;
+                  -h|--host)
+                    HOST="$2"
+                    shift 2
+                    ;;
+                  -h?*)
+                    HOST="${1#-h}"
+                    shift
+                    ;;
+                  --host=*)
+                    HOST="${1#*=}"
+                    shift
+                    ;;
+                  -p|--port)
+                    PORT="$2"
+                    shift 2
+                    ;;
+                  -p?*)
+                    PORT="${1#-p}"
+                    shift
+                    ;;
+                  --port=*)
+                    PORT="${1#*=}"
+                    shift
+                    ;;
                   *)
                     ARGS+=("$1")
                     shift
@@ -93,6 +119,19 @@ module Discharger
               if [[ -z "$HAS_USER" ]]; then
                 ARGS=("-U" "postgres" "${ARGS[@]}")
               fi
+
+              # Drop localhost host/port flags: they target the host-mapped
+              # port, but inside the container Postgres listens on its default
+              # port. Remote hosts pass through untouched.
+              case "$HOST" in
+                ""|localhost|127.0.0.1|::1) ;;
+                *)
+                  ARGS+=("-h" "$HOST")
+                  if [[ -n "$PORT" ]]; then
+                    ARGS+=("-p" "$PORT")
+                  fi
+                  ;;
+              esac
 
               if [[ -n "$OUTPUT_FILE" ]]; then
                 # Run pg_dump in container, output to stdout, redirect to local file
@@ -133,6 +172,8 @@ module Discharger
               # so we pipe file content via stdin instead
               INPUT_FILE=""
               HAS_USER=""
+              HOST=""
+              PORT=""
               ARGS=()
               while [[ $# -gt 0 ]]; do
                 case $1 in
@@ -153,6 +194,30 @@ module Discharger
                     ARGS+=("$1")
                     shift
                     ;;
+                  -h|--host)
+                    HOST="$2"
+                    shift 2
+                    ;;
+                  -h?*)
+                    HOST="${1#-h}"
+                    shift
+                    ;;
+                  --host=*)
+                    HOST="${1#*=}"
+                    shift
+                    ;;
+                  -p|--port)
+                    PORT="$2"
+                    shift 2
+                    ;;
+                  -p?*)
+                    PORT="${1#-p}"
+                    shift
+                    ;;
+                  --port=*)
+                    PORT="${1#*=}"
+                    shift
+                    ;;
                   *)
                     ARGS+=("$1")
                     shift
@@ -164,6 +229,19 @@ module Discharger
               if [[ -z "$HAS_USER" ]]; then
                 ARGS=("-U" "postgres" "${ARGS[@]}")
               fi
+
+              # Drop localhost host/port flags: they target the host-mapped
+              # port, but inside the container Postgres listens on its default
+              # port. Remote hosts pass through untouched.
+              case "$HOST" in
+                ""|localhost|127.0.0.1|::1) ;;
+                *)
+                  ARGS+=("-h" "$HOST")
+                  if [[ -n "$PORT" ]]; then
+                    ARGS+=("-p" "$PORT")
+                  fi
+                  ;;
+              esac
 
               if [[ -n "$INPUT_FILE" ]]; then
                 docker exec -i "$CONTAINER" #{tool} "${ARGS[@]}" < "$INPUT_FILE"

--- a/test/setup_runner/commands/pg_tools_command_test.rb
+++ b/test/setup_runner/commands/pg_tools_command_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 require "setup_runner_test_helper"
 require "discharger/setup_runner/commands/pg_tools_command"
 require "logger"
+require "open3"
 require "ostruct"
 
 class PgToolsCommandTest < ActiveSupport::TestCase
@@ -129,5 +130,61 @@ class PgToolsCommandTest < ActiveSupport::TestCase
     content = File.read(File.join(@test_dir, "bin", "pg-tools", "psql"))
     # Should NOT contain a bare "exec psql" without the FALLBACK variable
     refute_match(/^exec psql/, content)
+  end
+
+  test "psql wrapper drops localhost host and port before docker exec" do
+    capture_output { @command.execute }
+    args = docker_exec_args("psql", "-h", "localhost", "-p", "5434", "-d", "postgres", "-c", "SELECT 1")
+    assert_equal ["-U", "postgres", "-d", "postgres", "-c", "SELECT 1"], args
+  end
+
+  test "psql wrapper drops a bare port flag before docker exec" do
+    capture_output { @command.execute }
+    args = docker_exec_args("psql", "-p", "5434", "-d", "postgres")
+    assert_equal ["-U", "postgres", "-d", "postgres"], args
+  end
+
+  test "psql wrapper passes a remote host and port through to docker exec" do
+    capture_output { @command.execute }
+    args = docker_exec_args("psql", "-h", "db.example.com", "-p", "6543", "-d", "postgres")
+    assert_equal ["-U", "postgres", "-d", "postgres", "-h", "db.example.com", "-p", "6543"], args
+  end
+
+  test "pg_dump wrapper drops localhost host and port before docker exec" do
+    capture_output { @command.execute }
+    args = docker_exec_args("pg_dump", "-h", "127.0.0.1", "-p", "5434", "-d", "testapp_development")
+    assert_equal ["-U", "postgres", "-d", "testapp_development"], args
+  end
+
+  test "pg_dump wrapper passes a remote host and port through to docker exec" do
+    capture_output { @command.execute }
+    args = docker_exec_args("pg_dump", "-h", "db.example.com", "-p", "6543", "-d", "testapp_development")
+    assert_equal ["-U", "postgres", "-d", "testapp_development", "-h", "db.example.com", "-p", "6543"], args
+  end
+
+  private
+
+  def docker_exec_args(tool, *args)
+    stub_dir = File.join(@test_dir, "docker-stub")
+    FileUtils.mkdir_p(stub_dir)
+    stub_path = File.join(stub_dir, "docker")
+    File.write(stub_path, <<~BASH)
+      #!/usr/bin/env bash
+      if [[ "$1" == "ps" ]]; then
+        echo "db-testapp"
+        exit 0
+      fi
+      shift 4
+      printf '%s\\n' "$@"
+    BASH
+    FileUtils.chmod(0o755, stub_path)
+
+    wrapper = File.join(@test_dir, "bin", "pg-tools", tool)
+    out, err, status = Open3.capture3(
+      {"PATH" => "#{stub_dir}:#{ENV["PATH"]}"},
+      wrapper, *args
+    )
+    assert status.success?, "wrapper failed: #{err}"
+    out.split("\n")
   end
 end

--- a/test/setup_runner/commands/pg_tools_command_test.rb
+++ b/test/setup_runner/commands/pg_tools_command_test.rb
@@ -162,9 +162,53 @@ class PgToolsCommandTest < ActiveSupport::TestCase
     assert_equal ["-U", "postgres", "-d", "testapp_development", "-h", "db.example.com", "-p", "6543"], args
   end
 
+  test "psql wrapper drops attached localhost host and port flags" do
+    capture_output { @command.execute }
+    args = docker_exec_args("psql", "-hlocalhost", "-p5434", "-d", "postgres")
+    assert_equal ["-U", "postgres", "-d", "postgres"], args
+  end
+
+  test "psql wrapper drops equals-form localhost host and port flags" do
+    capture_output { @command.execute }
+    args = docker_exec_args("psql", "--host=localhost", "--port=5434", "-d", "postgres")
+    assert_equal ["-U", "postgres", "-d", "postgres"], args
+  end
+
+  test "psql wrapper passes equals-form remote host and port through to docker exec" do
+    capture_output { @command.execute }
+    args = docker_exec_args("psql", "--host=db.example.com", "--port=6543", "-d", "postgres")
+    assert_equal ["-U", "postgres", "-d", "postgres", "-h", "db.example.com", "-p", "6543"], args
+  end
+
+  test "pg_dump wrapper drops attached localhost host and port flags" do
+    capture_output { @command.execute }
+    args = docker_exec_args("pg_dump", "-h127.0.0.1", "-p5434", "-d", "testapp_development")
+    assert_equal ["-U", "postgres", "-d", "testapp_development"], args
+  end
+
+  test "pg_dump wrapper passes attached remote host and port through to docker exec" do
+    capture_output { @command.execute }
+    args = docker_exec_args("pg_dump", "-hdb.example.com", "-p6543", "-d", "testapp_development")
+    assert_equal ["-U", "postgres", "-d", "testapp_development", "-h", "db.example.com", "-p", "6543"], args
+  end
+
+  test "psql wrapper fails with a clear error when a host flag is missing its value" do
+    capture_output { @command.execute }
+    _out, err, status = run_wrapper("psql", "-d", "postgres", "-h")
+    refute status.success?
+    assert_includes err, "-h requires an argument"
+  end
+
+  test "psql wrapper fails with a clear error when a port flag is missing its value" do
+    capture_output { @command.execute }
+    _out, err, status = run_wrapper("psql", "-d", "postgres", "--port")
+    refute status.success?
+    assert_includes err, "--port requires an argument"
+  end
+
   private
 
-  def docker_exec_args(tool, *args)
+  def run_wrapper(tool, *args)
     stub_dir = File.join(@test_dir, "docker-stub")
     FileUtils.mkdir_p(stub_dir)
     stub_path = File.join(stub_dir, "docker")
@@ -180,10 +224,14 @@ class PgToolsCommandTest < ActiveSupport::TestCase
     FileUtils.chmod(0o755, stub_path)
 
     wrapper = File.join(@test_dir, "bin", "pg-tools", tool)
-    out, err, status = Open3.capture3(
+    Open3.capture3(
       {"PATH" => "#{stub_dir}:#{ENV["PATH"]}"},
       wrapper, *args
     )
+  end
+
+  def docker_exec_args(tool, *args)
+    out, err, status = run_wrapper(tool, *args)
     assert status.success?, "wrapper failed: #{err}"
     out.split("\n")
   end


### PR DESCRIPTION
## Summary

The generated `bin/pg-tools` psql/pg_dump wrappers pass all caller arguments straight through to `docker exec`, including `-h localhost -p <mapped-port>`. Inside the container Postgres listens on its default port — the mapped port only exists on the host side of the Docker port mapping — so any caller using the documented host-mapped port got "connection refused" whenever the database container was running.

This bit Qualify in practice: `.envrc` puts `bin/pg-tools` first on PATH via direnv, and `bin/dev-db` always passes `-h localhost -p 5434`, so every `bin/dev-db` command (including the `refresh-template` step at the end of `bin/setup`) failed while the `db-qualify` container was up. Qualify-side context: SOFware/qualify#5446.

## What changed

Both wrapper templates now track `-h`/`--host` and `-p`/`--port` (separate, attached, and `=` forms) while parsing arguments. When the host is localhost (`localhost`, `127.0.0.1`, `::1`) or absent, the flags are dropped so the in-container psql/pg_dump uses its own defaults. A non-localhost host passes through untouched along with its port, so pointing the wrapper at a remote database still reaches that database instead of being silently redirected into the local container.

## Testing

New behavioral tests generate the wrappers, put a stub `docker` on PATH, execute them, and assert on the argument vector that reaches `docker exec`: localhost host/port dropped, bare `-p` dropped, and remote host/port preserved, for both psql and pg_dump. The full suite passes (281 runs, 0 failures). Also verified end-to-end against a real container: a wrapper generated from this template connects successfully with `psql -h localhost -p 5434`, which fails with the current template.