### PR TITLE
Announce the post-release runbook in the release thread

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       prism (>= 0.19.0)
       rails (>= 7.2.1)
       rainbow
-      reissue
+      reissue (>= 0.5)
       slack-ruby-client
 
 GEM
@@ -215,13 +215,13 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
     regexp_parser (2.12.0)
-    reissue (0.4.22)
+    reissue (0.5.0)
       rake
     reline (0.6.3)
       io-console (~> 0.5)
@@ -297,4 +297,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.6.8
+   2.6.7

--- a/README.md
+++ b/README.md
@@ -89,6 +89,51 @@ changelog.d/
 
 Each fragment file should contain the changelog entry for a specific change or feature.
 
+### Post-release Runbook
+
+Some releases need manual follow-up: run a rake task, backfill data, re-index documents.
+Reissue collects those steps from `Runbook:` commit trailers, and Discharger announces
+them to your team in the release thread.
+
+```ruby
+Discharger::Task.create do |task|
+  # ... other configuration ...
+  task.runbook_file = "RUNBOOK.md"  # Default: nil (disabled)
+end
+```
+
+Add steps as you work, in the same commit as the change that requires them:
+
+```bash
+git commit -m "Add data migration
+
+Fixed: Duplicate user records
+Runbook: Run \`rake data:cleanup\` after deploy"
+```
+
+`rake release:prepare` finalizes the runbook alongside the changelog, so the release tag
+records exactly which steps that version needs. After the production release, Discharger
+posts the checklist to Slack as a reply in the release thread, right after the changelog:
+
+```
+*Post-release runbook for 1.2.3* — 2 steps
+
+• Run `rake data:cleanup` (abc1234)
+• Re-index search documents (def5678)
+```
+
+When a release needs no follow-up, the thread says so explicitly rather than staying
+silent, so nobody has to wonder whether the check was skipped:
+
+```
+*Post-release runbook for 1.2.3*
+No runbook tasks for this release.
+```
+
+Leave `runbook_file` unset and Discharger posts nothing extra. See the
+[Reissue runbook documentation](https://github.com/SOFware/reissue#post-release-runbook)
+for how items are collected and merged.
+
 ## Available Tasks
 
 The gem creates several Rake tasks for managing your deployment workflow:

--- a/discharger.gemspec
+++ b/discharger.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "prism", ">= 0.19.0"
   spec.add_dependency "rails", ">= 7.2.1"
   spec.add_dependency "rainbow"
-  spec.add_dependency "reissue"
+  spec.add_dependency "reissue", ">= 0.5"
   spec.add_dependency "slack-ruby-client"
 end

--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -24,6 +24,7 @@ module Discharger
         reissue.fragment = task.fragment
         reissue.clear_fragments = task.clear_fragments
         reissue.tag_pattern = task.tag_pattern
+        reissue.runbook_file = task.runbook_file
       end
       task.define
       task
@@ -179,6 +180,27 @@ module Discharger
       stdout.strip
     end
 
+    # The post-release steps collected from "Runbook:" commit trailers.
+    # Empty when no runbook is configured or the file has yet to be written.
+    def runbook_items
+      return [] unless runbook_file
+
+      Reissue::Runbook.new(Rails.root.join(runbook_file).to_s).items
+    end
+
+    # Build the Slack message listing the post-release steps for a version.
+    # Returns nil when the project does not use a runbook, which is distinct
+    # from a configured runbook that happens to have no steps this release.
+    def runbook_announcement(version, items = runbook_items)
+      return nil unless runbook_file
+
+      header = "*Post-release runbook for #{version}*"
+      return "#{header}\nNo runbook tasks for this release." if items.empty?
+
+      "#{header} — #{items.size} step#{"s" unless items.size == 1}\n\n" +
+        items.map { |item| "• #{item}" }.join("\n")
+    end
+
     def existing_pr_number(base, head)
       stdout, _, status = Open3.capture3(
         "gh", "pr", "list",
@@ -286,10 +308,17 @@ module Discharger
           ["git push origin v#{current_version}"]
         ) do
           tasker["#{name}:slack"].invoke("Released #{app_name} #{current_version} (#{commit_identifier.call}) to production.", release_message_channel, ":chipmunk:")
-          if last_message_ts.present?
+          # Capture the root before replying; each post overwrites last_message_ts.
+          thread_ts = last_message_ts
+          if thread_ts.present?
             text = File.read(Rails.root.join(changelog_file))
             tasker["#{name}:slack"].reenable
-            tasker["#{name}:slack"].invoke(text, release_message_channel, ":log:", last_message_ts)
+            tasker["#{name}:slack"].invoke(text, release_message_channel, ":log:", thread_ts)
+
+            if (runbook_message = runbook_announcement(current_version))
+              tasker["#{name}:slack"].reenable
+              tasker["#{name}:slack"].invoke(runbook_message, release_message_channel, ":clipboard:", thread_ts)
+            end
           end
           # Signal success — no branch switch needed since we stay on working_branch throughout
           true

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -367,3 +367,209 @@ class DischargerExistingPrNumberTest < Minitest::Test
     assert_nil @task.existing_pr_number("main", "develop")
   end
 end
+
+class DischargerRunbookAnnouncementTest < Minitest::Test
+  def setup
+    @task = Discharger::Task.new
+  end
+
+  def test_returns_nil_when_runbook_is_not_configured
+    assert_nil @task.runbook_announcement("1.2.3", ["Run `rake data:cleanup`"])
+  end
+
+  def test_reports_no_tasks_when_runbook_is_empty
+    @task.runbook_file = "RUNBOOK.md"
+
+    assert_equal <<~MSG.chomp, @task.runbook_announcement("1.2.3", [])
+      *Post-release runbook for 1.2.3*
+      No runbook tasks for this release.
+    MSG
+  end
+
+  def test_uses_singular_step_for_a_single_item
+    @task.runbook_file = "RUNBOOK.md"
+
+    assert_equal <<~MSG.chomp, @task.runbook_announcement("1.2.3", ["Run `rake data:cleanup`"])
+      *Post-release runbook for 1.2.3* — 1 step
+
+      • Run `rake data:cleanup`
+    MSG
+  end
+
+  def test_lists_every_item_as_a_bullet
+    @task.runbook_file = "RUNBOOK.md"
+    items = ["Run `rake data:cleanup` (abc1234)", "Re-index search documents (def5678)"]
+
+    assert_equal <<~MSG.chomp, @task.runbook_announcement("1.2.3", items)
+      *Post-release runbook for 1.2.3* — 2 steps
+
+      • Run `rake data:cleanup` (abc1234)
+      • Re-index search documents (def5678)
+    MSG
+  end
+
+  def test_runbook_items_are_empty_when_runbook_is_not_configured
+    assert_empty @task.runbook_items
+  end
+
+  def test_runbook_items_reads_checklist_text_from_the_runbook_file
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "RUNBOOK.md")
+      File.write(path, <<~MARKDOWN)
+        # Runbook
+
+        Steps to perform after releasing the version below.
+
+        ## [1.2.3] - 2026-07-21
+
+        - [ ] Run `rake data:cleanup` (abc1234)
+        - [x] Re-index search documents (def5678)
+      MARKDOWN
+
+      @task.runbook_file = path
+
+      assert_equal [
+        "Run `rake data:cleanup` (abc1234)",
+        "Re-index search documents (def5678)"
+      ], @task.runbook_items
+    end
+  end
+end
+
+class DischargerRunbookForwardingTest < Minitest::Test
+  def test_create_forwards_runbook_file_to_reissue
+    captured_runbook_file = nil
+
+    original_create = Reissue::Task.method(:create)
+    Reissue::Task.define_singleton_method(:create) do |name = :reissue, &block|
+      reissue_task = Reissue::Task.new(name)
+      block&.call(reissue_task)
+      captured_runbook_file = reissue_task.runbook_file
+      reissue_task
+    end
+
+    Discharger::Task.create(:test_runbook_file) do
+      self.version_file = "VERSION"
+      self.runbook_file = "RUNBOOK.md"
+    end
+
+    assert_equal "RUNBOOK.md", captured_runbook_file
+  ensure
+    Reissue::Task.define_singleton_method(:create, original_create)
+  end
+end
+
+class DischargerReleaseThreadTest < Minitest::Test
+  FAKE_VERSION = "1.2.3"
+
+  def setup
+    @slack_calls = []
+    @original_stdin = $stdin
+    Rake::Task.define_task(:environment) {} unless Rake::Task.task_defined?(:environment)
+
+    # The release task reads the changelog straight off disk to post it to Slack.
+    @changelog_path = Rails.root.join("CHANGELOG.md")
+    File.write(@changelog_path, "## [1.2.3]\n\n### Fixed\n\n- A bug\n")
+  end
+
+  def teardown
+    $stdin = @original_stdin
+    FileUtils.rm_f(@changelog_path)
+  end
+
+  # Builds a task whose :slack subtask records its arguments and assigns a new
+  # message timestamp on each post, the way the real Slack task does.
+  def build_task(name, runbook_items: nil)
+    holder = []
+    slack_calls = @slack_calls
+    timestamps = ["ROOT.1", "REPLY.1", "REPLY.2"]
+
+    noop = Object.new
+    noop.define_singleton_method(:invoke) { |*_args| }
+    noop.define_singleton_method(:reenable) {}
+
+    slack = Object.new
+    slack.define_singleton_method(:reenable) {}
+    slack.define_singleton_method(:invoke) do |*args|
+      slack_calls << args
+      holder.first.instance_variable_set(:@last_message_ts, timestamps.shift)
+    end
+
+    tasker = Object.new
+    tasker.define_singleton_method(:[]) do |task_name|
+      task_name.to_s.end_with?(":slack") ? slack : noop
+    end
+
+    task = Discharger::Task.new(name, tasker:)
+    holder << task
+
+    task.version_constant = "DischargerReleaseThreadTest::FAKE_VERSION"
+    task.version_file = "VERSION"
+    task.changelog_file = "CHANGELOG.md"
+    task.release_message_channel = "#releases"
+    task.chat_token = "fake_token"
+    task.pull_request_url = "http://example.com"
+    task.app_name = "TestApp"
+    task.commit_identifier = -> { "abc123" }
+    task.runbook_file = runbook_items && "RUNBOOK.md"
+
+    task.define_singleton_method(:syscall) do |*_steps, **_kwargs, &block|
+      block&.call("", "", nil)
+      true
+    end
+    task.define_singleton_method(:sysecho) { |*_args, **_kwargs| true }
+    task.define_singleton_method(:validate_version_match!) { |*_args, **_kwargs| true }
+    task.define_singleton_method(:validate_release_commit!) { |*_args, **_kwargs| true }
+    task.define_singleton_method(:existing_pr_number) { |*_args| nil }
+    task.define_singleton_method(:pr_already_merged?) { |_ref| false }
+    task.define_singleton_method(:runbook_items) { runbook_items || [] }
+
+    task
+  end
+
+  def run_release(name, runbook_items: nil)
+    task = build_task(name, runbook_items:)
+    task.define
+    $stdin = StringIO.new("\n")
+    capture_io { Rake::Task[name.to_s].invoke }
+    task
+  end
+
+  def test_posts_runbook_as_a_reply_in_the_release_thread
+    run_release(:rel_runbook, runbook_items: ["Run `rake data:cleanup`"])
+
+    assert_equal 3, @slack_calls.size, "Expected announcement, changelog, and runbook"
+
+    runbook_text, channel, emoji, ts = @slack_calls.last
+    assert_match(/Post-release runbook for 1\.2\.3/, runbook_text)
+    assert_match(/• Run `rake data:cleanup`/, runbook_text)
+    assert_equal "#releases", channel
+    assert_equal ":clipboard:", emoji
+    assert_equal "ROOT.1", ts, "Runbook must thread off the release announcement"
+  end
+
+  def test_threads_changelog_and_runbook_off_the_release_announcement
+    run_release(:rel_thread_root, runbook_items: ["Rotate the signing key"])
+
+    changelog_ts = @slack_calls[1][3]
+    runbook_ts = @slack_calls[2][3]
+
+    assert_equal "ROOT.1", changelog_ts
+    assert_equal "ROOT.1", runbook_ts,
+      "Runbook must thread off the root, not off the changelog reply"
+  end
+
+  def test_reports_no_tasks_when_runbook_is_configured_but_empty
+    run_release(:rel_runbook_empty, runbook_items: [])
+
+    assert_equal 3, @slack_calls.size
+    assert_match(/No runbook tasks for this release\./, @slack_calls.last.first)
+  end
+
+  def test_posts_nothing_extra_when_runbook_is_not_configured
+    run_release(:rel_no_runbook, runbook_items: nil)
+
+    assert_equal 2, @slack_calls.size,
+      "Projects without a runbook should only get the announcement and changelog"
+  end
+end


### PR DESCRIPTION
Uses Reissue 0.5's `runbook_file` option so manual post-release steps reach the people who have to perform them.

Verified against the **published reissue 0.5.0**: 299 runs, 0 failures, `standardrb` clean.

## The bug

Discharger already sits on both ends of the runbook lifecycle:

| Discharger step | Reissue task | Runbook effect |
|---|---|---|
| `release:prepare` (STEP 1) | `reissue:finalize` | trailers merged, header stamped, committed |
| `release` (STEP 3) | `reissue` | cleared back to `## [Unreleased]` |

But `Task.create` forwards settings to `Reissue::Task` through a hardcoded list that omitted `runbook_file`. The accessor is generated by reflection over `Reissue::Task.instance_methods`, so `task.runbook_file = "RUNBOOK.md"` *set* cleanly and was then silently dropped — `runbook_file` was `nil` inside finalize and reissue skipped the feature. One line fixes it.

Verified end-to-end in a scratch repo — a commit carrying `Runbook: Run \`rake data:cleanup\` after deploy`, then `reissue:finalize`:

```
Finalize the changelog for version 1.2.3 on 2026-07-21
 CHANGELOG.md | 5 ++++-
 RUNBOOK.md   | 7 +++++++
```

RUNBOOK.md rides along in the finalize commit, so the release tag contains the finalized runbook.

## The announcement

After the production release, the checklist posts as a reply in the Slack release thread, right after the changelog:

```
*Post-release runbook for 1.2.3* — 2 steps

• Run `rake data:cleanup` (abc1234)
• Re-index search documents (def5678)
```

A configured-but-empty runbook says so explicitly rather than staying silent, so nobody wonders whether the check was skipped:

```
*Post-release runbook for 1.2.3*
No runbook tasks for this release.
```

Projects that leave `runbook_file` unset get nothing extra.

Reading the runbook at release time is well-ordered by construction: after finalize stamped the file, before the version bump clears it.

## Dependency

`reissue >= 0.5` — `Reissue::Runbook` does not exist in 0.4.x. `Gemfile.lock` moves 0.4.22 → 0.5.0.

The floor is deliberately permissive (`>= 0.5`, not `~> 0.5`) to match this gem's existing unconstrained-dependency style. Worth a second opinion: reissue is 0.x, where a minor bump may break, so `~> 0.5` would be the more conservative call at the cost of blocking consuming apps from adopting reissue 0.6.

## Drive-by fix

`last_message_ts` is reassigned by every `:slack` invoke, so after the changelog reply it pointed at *the reply* rather than the release announcement — a second reply would have threaded off the wrong message. The thread root is now captured before replying. Slack flattens replies-to-replies so this was never visible, but it made correctness depend on that behavior. Mutation-tested: reverting to `last_message_ts` fails with `Expected "ROOT.1", Actual "REPLY.1"`.

## Not addressed

The same forwarding gap still exists for `retain_changelogs`, `changelog_sections`, `push_finalize`, `push_reissue`, `commit_clear_fragments`, and `deferred_versioning`. Replacing the hardcoded list with a loop over the reflected accessor list would fix all of them plus every future reissue option — left to a separate PR to keep this one reviewable.
