### PR TITLE
Announce the runbook on stage builds too

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ Runbook: Run \`rake data:cleanup\` after deploy"
 ```
 
 `rake release:prepare` finalizes the runbook alongside the changelog, so the release tag
-records exactly which steps that version needs. After the production release, Discharger
-posts the checklist to Slack as a reply in the release thread, right after the changelog:
+records exactly which steps that version needs. Discharger posts the checklist to Slack as
+a reply in the deploy thread — both on the stage build (`rake release:build` /
+`rake release:stage`, threaded under "Building…") and after the production release
+(threaded under the release announcement, right after the changelog):
 
 ```
 *Post-release runbook for 1.2.3* — 2 steps
@@ -121,6 +123,9 @@ posts the checklist to Slack as a reply in the release thread, right after the c
 • Run `rake data:cleanup` (abc1234)
 • Re-index search documents (def5678)
 ```
+
+Staging shows the steps as a preview so the team sees what production will need before it
+happens; the production thread repeats them when the release actually lands.
 
 When a release needs no follow-up, the thread says so explicitly rather than staying
 silent, so nobody has to wonder whether the check was skipped:

--- a/lib/discharger/task.rb
+++ b/lib/discharger/task.rb
@@ -201,6 +201,19 @@ module Discharger
         items.map { |item| "• #{item}" }.join("\n")
     end
 
+    # Post the runbook as a reply in a Slack thread, when a runbook is
+    # configured. Reuses the same message on the stage build and the
+    # production release. Returns the message posted, or nil when there is
+    # no thread to reply to or no runbook to announce.
+    def post_runbook_to_thread(version, thread_ts)
+      return unless thread_ts.present?
+      return unless (message = runbook_announcement(version))
+
+      tasker["#{name}:slack"].reenable
+      tasker["#{name}:slack"].invoke(message, release_message_channel, ":clipboard:", thread_ts)
+      message
+    end
+
     def existing_pr_number(base, head)
       stdout, _, status = Open3.capture3(
         "gh", "pr", "list",
@@ -315,10 +328,7 @@ module Discharger
             tasker["#{name}:slack"].reenable
             tasker["#{name}:slack"].invoke(text, release_message_channel, ":log:", thread_ts)
 
-            if (runbook_message = runbook_announcement(current_version))
-              tasker["#{name}:slack"].reenable
-              tasker["#{name}:slack"].invoke(runbook_message, release_message_channel, ":clipboard:", thread_ts)
-            end
+            post_runbook_to_thread(current_version, thread_ts)
           end
           # Signal success — no branch switch needed since we stay on working_branch throughout
           true
@@ -385,6 +395,7 @@ module Discharger
           ) do
             current_version = Object.const_get(version_constant)
             tasker["#{name}:slack"].invoke("Building #{app_name} #{current_version} (#{commit_identifier.call}) on #{staging_branch}.", release_message_channel)
+            post_runbook_to_thread(current_version, last_message_ts)
             syscall ["git checkout #{build_branch}"]
           end
         end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -573,3 +573,90 @@ class DischargerReleaseThreadTest < Minitest::Test
       "Projects without a runbook should only get the announcement and changelog"
   end
 end
+
+class DischargerStageAnnouncementTest < Minitest::Test
+  FAKE_VERSION = "1.2.3"
+
+  def setup
+    @slack_calls = []
+    Rake::Task.define_task(:environment) {} unless Rake::Task.task_defined?(:environment)
+  end
+
+  # Builds a task whose :slack subtask records its arguments and assigns a new
+  # message timestamp on each post, the way the real Slack task does.
+  def build_task(name, runbook_items: nil)
+    holder = []
+    slack_calls = @slack_calls
+    timestamps = ["ROOT.1", "REPLY.1"]
+
+    noop = Object.new
+    noop.define_singleton_method(:invoke) { |*_args| }
+    noop.define_singleton_method(:reenable) {}
+
+    slack = Object.new
+    slack.define_singleton_method(:reenable) {}
+    slack.define_singleton_method(:invoke) do |*args|
+      slack_calls << args
+      holder.first.instance_variable_set(:@last_message_ts, timestamps.shift)
+    end
+
+    tasker = Object.new
+    tasker.define_singleton_method(:[]) do |task_name|
+      task_name.to_s.end_with?(":slack") ? slack : noop
+    end
+
+    task = Discharger::Task.new(name, tasker:)
+    holder << task
+
+    task.version_constant = "DischargerStageAnnouncementTest::FAKE_VERSION"
+    task.version_file = "VERSION"
+    task.release_message_channel = "#releases"
+    task.chat_token = "fake_token"
+    task.app_name = "TestApp"
+    task.commit_identifier = -> { "abc123" }
+    task.runbook_file = runbook_items && "RUNBOOK.md"
+
+    task.define_singleton_method(:syscall) do |*_steps, **_kwargs, &block|
+      block&.call("", "", nil)
+      true
+    end
+    task.define_singleton_method(:sysecho) { |*_args, **_kwargs| true }
+    task.define_singleton_method(:runbook_items) { runbook_items || [] }
+
+    task
+  end
+
+  def run_build(name, runbook_items: nil)
+    task = build_task(name, runbook_items:)
+    task.define
+    capture_io { Rake::Task["#{name}:build"].invoke }
+    task
+  end
+
+  def test_build_posts_runbook_as_a_reply_in_the_stage_thread
+    run_build(:stage_runbook, runbook_items: ["Run `rake data:cleanup`"])
+
+    assert_equal 2, @slack_calls.size, "Expected the build announcement and the runbook"
+
+    runbook_text, channel, emoji, ts = @slack_calls.last
+    assert_match(/Post-release runbook for 1\.2\.3/, runbook_text)
+    assert_match(/• Run `rake data:cleanup`/, runbook_text)
+    assert_equal "#releases", channel
+    assert_equal ":clipboard:", emoji
+    assert_equal "ROOT.1", ts, "Runbook must thread off the build announcement"
+  end
+
+  def test_build_reports_no_tasks_when_runbook_is_configured_but_empty
+    run_build(:stage_runbook_empty, runbook_items: [])
+
+    assert_equal 2, @slack_calls.size
+    assert_match(/No runbook tasks for this release\./, @slack_calls.last.first)
+  end
+
+  def test_build_posts_nothing_extra_when_runbook_is_not_configured
+    run_build(:stage_no_runbook, runbook_items: nil)
+
+    assert_equal 1, @slack_calls.size,
+      "Projects without a runbook should only get the build announcement"
+  end
+end


### PR DESCRIPTION
Extends the runbook announcement (#221) to the **stage** deploy, not just production.

> **Stacked on #221.** Base is `feature/runbook-slack-announcement`, so this diff shows only the stage work. It can't merge until #221 does — `post_runbook_to_thread` builds on the `runbook_announcement`/`runbook_items` methods that PR introduces. After #221 merges, GitHub retargets this to `main` automatically.

## What changed

The runbook now posts as a reply in the **stage** deploy thread too — threaded under the "Building… on stage" message that `release:build` (and therefore `release:stage`) already posts:

```
Building TestApp 1.2.3 (abc123) on stage.
  └─ *Post-release runbook for 1.2.3* — 2 steps

     • Run `rake data:cleanup` (abc1234)
     • Re-index search documents (def5678)
```

Staging shows the steps as a **preview** so the team sees what production will need before it happens; the production thread still repeats them when the release lands.

## How

`post_runbook_to_thread(version, thread_ts)` is extracted from the production release block and called from both sites. The production path collapses to the helper with **identical output** — the existing release-thread tests cover the refactor, and they stayed green.

Which runbook the stage message shows follows from *where build reads the file*: `build` checks out the working branch, so a staged release-candidate (post-`prepare`) shows its finalized runbook, and a standalone `release:build` shows the in-progress one. Both are the useful thing to preview.

Parity with production is preserved: unconfigured `runbook_file` → nothing extra; configured-but-empty → "No runbook tasks for this release."

## Tests

3 new tests (`DischargerStageAnnouncementTest`), watched failing first (build posted 1 message, tests wanted 2). Full suite: **302 runs, 0 failures**, `standardrb` clean, against published reissue 0.5.0.