### PR TITLE
Configure GitHub Packages credentials from the gh CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ The `steps` array specifies which built-in setup commands to run. Available comm
 - `brew` - Install Homebrew dependencies
 - `asdf` - Setup version management with asdf
 - `git` - Configure git settings
+- `github_packages` - Store bundler credentials for a private GitHub Packages gem source using the GitHub CLI (run before `bundler`; requires a `github_packages.source` config entry)
 - `bundler` - Install Ruby gems
 - `yarn` - Install JavaScript packages
 - `config` - Copy configuration files

--- a/lib/discharger/setup_runner/commands/github_packages_command.rb
+++ b/lib/discharger/setup_runner/commands/github_packages_command.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative "base_command"
+
+module Discharger
+  module SetupRunner
+    module Commands
+      # Stores bundler credentials for a private GitHub Packages gem source
+      # using the GitHub CLI, so Gemfiles don't need embedded tokens.
+      # Credentials are written to the app's .bundle/config — keep .bundle
+      # gitignored. Run this step before "bundler" in setup.yml.
+      class GithubPackagesCommand < BaseCommand
+        def execute
+          unless gh_installed?
+            log "GitHub CLI (gh) not found; skipping. Install gh and rerun setup or `bundle install` may fail for #{source}"
+            return
+          end
+
+          unless authenticated? || login
+            log "Not logged in to GitHub; skipping. Run `gh auth login` and rerun setup."
+            return
+          end
+
+          username = gh("api", "user", "--jq", ".login")
+          token = gh("auth", "token")
+          if username.to_s.empty? || token.to_s.empty?
+            log "Could not read GitHub credentials from gh; skipping."
+            return
+          end
+
+          store_bundler_credentials(username, token)
+          if credentials_valid?(username, token)
+            log "Configured bundler credentials for #{source}"
+          else
+            log "#{source} rejected the stored credentials. Your gh token may lack " \
+              "the read:packages scope — run `gh auth refresh -s read:packages` and rerun setup."
+          end
+        end
+
+        def can_execute?
+          !source.to_s.empty?
+        end
+
+        def description
+          "Configure GitHub Packages credentials"
+        end
+
+        protected
+
+        def source
+          config.github_packages&.source if config.respond_to?(:github_packages)
+        end
+
+        def gh_installed?
+          system_quiet("which gh")
+        end
+
+        def authenticated?
+          system_quiet("gh auth status")
+        end
+
+        def login
+          return false unless $stdin.tty?
+          log "Logging in to GitHub..."
+          system("gh", "auth", "login")
+          authenticated?
+        end
+
+        def gh(*args)
+          require "open3"
+          stdout, _stderr, status = Open3.capture3("gh", *args)
+          status.success? ? stdout.chomp : nil
+        end
+
+        # Runs bundle config directly instead of through system! so the
+        # token never reaches the spinner display or the debug log.
+        def store_bundler_credentials(username, token)
+          require "open3"
+          _stdout, stderr, status = Open3.capture3(
+            "bundle", "config", "set", "--local", source, "#{username}:#{token}"
+          )
+          raise "bundle config set --local #{source} failed: #{stderr}" unless status.success?
+        end
+
+        # Probes the source's compact index with the stored credentials.
+        # Only a definite 401/403 counts as invalid — network trouble must
+        # not fail setup over an unverifiable token.
+        def credentials_valid?(username, token)
+          require "net/http"
+          require "uri"
+          uri = URI.join("#{source.chomp("/")}/", "versions")
+          response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
+            open_timeout: 5, read_timeout: 10) do |http|
+            request = Net::HTTP::Get.new(uri)
+            request.basic_auth(username, token)
+            http.request(request)
+          end
+          !%w[401 403].include?(response.code)
+        rescue => e
+          logger&.debug("Could not verify GitHub Packages credentials: #{e.message}")
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/discharger/setup_runner/configuration.rb
+++ b/lib/discharger/setup_runner/configuration.rb
@@ -5,12 +5,13 @@ require "yaml"
 module Discharger
   module SetupRunner
     class Configuration
-      attr_accessor :app_name, :database, :redis, :services, :steps, :custom_steps, :pre_steps
+      attr_accessor :app_name, :database, :redis, :github_packages, :services, :steps, :custom_steps, :pre_steps
 
       def initialize
         @app_name = "Application"
         @database = DatabaseConfig.new
         @redis = nil
+        @github_packages = nil
         @services = []
         @steps = []
         @custom_steps = []
@@ -27,6 +28,7 @@ module Discharger
         config.app_name = yaml["app_name"] if yaml["app_name"]
         config.database.from_hash(yaml["database"]) if yaml["database"]
         config.redis = RedisConfig.new.tap { |r| r.from_hash(yaml["redis"]) } if yaml["redis"]
+        config.github_packages = GithubPackagesConfig.new.tap { |g| g.from_hash(yaml["github_packages"]) } if yaml["github_packages"]
         config.services = yaml["services"] || []
         config.steps = yaml["steps"] || []
         config.custom_steps = yaml["custom_steps"] || []
@@ -53,6 +55,18 @@ module Discharger
         @version = hash["version"] if hash["version"]
         @password = hash["password"] if hash["password"]
         @prefer_docker = hash["prefer_docker"] if hash.key?("prefer_docker")
+      end
+    end
+
+    class GithubPackagesConfig
+      attr_accessor :source
+
+      def initialize
+        @source = nil
+      end
+
+      def from_hash(hash)
+        @source = hash["source"] if hash["source"]
       end
     end
 

--- a/lib/generators/discharger/install/templates/setup.yml
+++ b/lib/generators/discharger/install/templates/setup.yml
@@ -18,6 +18,14 @@ redis:
   name: "redis-your-app"
   version: "latest"
 
+# Private GitHub Packages gem source (optional)
+# Stores bundler credentials from the GitHub CLI (gh) so the Gemfile
+# doesn't need an embedded token. Add "github_packages" to steps, before
+# "bundler". Credentials are written to .bundle/config — keep .bundle
+# gitignored.
+# github_packages:
+#   source: "https://rubygems.pkg.github.com/your-org"
+
 # Pre-Rails steps (run BEFORE Rails loads)
 # These are for system dependencies and environment setup that must happen
 # before bundler/Rails can initialize. Use sparingly.
@@ -36,7 +44,7 @@ pre_steps: []
   # - postgresql_tools # Optional: for apps that use structure.sql or pg_dump/psql directly
 
 # Built-in commands to run (empty array runs all available commands)
-# Available commands: brew, asdf, git, bundler, yarn, config, docker, pg_tools, env, database
+# Available commands: brew, asdf, git, github_packages, bundler, yarn, config, docker, pg_tools, env, database
 steps:
   - brew
   - asdf

--- a/test/setup_runner/commands/github_packages_command_test.rb
+++ b/test/setup_runner/commands/github_packages_command_test.rb
@@ -1,0 +1,197 @@
+require "test_helper"
+require "setup_runner_test_helper"
+require "discharger/setup_runner/configuration"
+require "discharger/setup_runner/commands/github_packages_command"
+require "logger"
+require "socket"
+
+class GithubPackagesCommandTest < ActiveSupport::TestCase
+  include SetupRunnerTestHelper
+
+  SOURCE = "https://rubygems.pkg.github.com/example"
+
+  def setup
+    super
+    @config = Discharger::SetupRunner::Configuration.new
+    @config.github_packages = Discharger::SetupRunner::GithubPackagesConfig.new.tap do |g|
+      g.source = SOURCE
+    end
+    @logger = Logger.new(StringIO.new)
+    @command = Discharger::SetupRunner::Commands::GithubPackagesCommand.new(@config, @test_dir, @logger)
+  end
+
+  test "description returns correct text" do
+    assert_equal "Configure GitHub Packages credentials", @command.description
+  end
+
+  test "can_execute? returns true when a source is configured" do
+    assert @command.can_execute?
+  end
+
+  test "can_execute? returns false when no github_packages config is present" do
+    @config.github_packages = nil
+    refute @command.can_execute?
+  end
+
+  test "can_execute? returns false when the source is empty" do
+    @config.github_packages.source = ""
+    refute @command.can_execute?
+  end
+
+  test "execute stores and verifies credentials when gh is installed and authenticated" do
+    stored = []
+    stub_shell(gh_installed: true, authenticated: true,
+      gh_outputs: {["api", "user", "--jq", ".login"] => "octocat", ["auth", "token"] => "gho_secret"})
+    @command.define_singleton_method(:store_bundler_credentials) { |user, token| stored << [user, token] }
+    @command.define_singleton_method(:credentials_valid?) { |_user, _token| true }
+
+    @command.execute
+
+    assert_equal [["octocat", "gho_secret"]], stored
+  end
+
+  test "execute skips without storing credentials when gh is not installed" do
+    stored = []
+    stub_shell(gh_installed: false, authenticated: false, gh_outputs: {})
+    @command.define_singleton_method(:store_bundler_credentials) { |user, token| stored << [user, token] }
+
+    @command.execute
+
+    assert_empty stored
+  end
+
+  test "execute skips without storing credentials when not authenticated and login fails" do
+    stored = []
+    stub_shell(gh_installed: true, authenticated: false, gh_outputs: {})
+    @command.define_singleton_method(:login) { false }
+    @command.define_singleton_method(:store_bundler_credentials) { |user, token| stored << [user, token] }
+
+    @command.execute
+
+    assert_empty stored
+  end
+
+  test "execute skips without storing credentials when gh returns no token" do
+    stored = []
+    stub_shell(gh_installed: true, authenticated: true,
+      gh_outputs: {["api", "user", "--jq", ".login"] => "octocat", ["auth", "token"] => nil})
+    @command.define_singleton_method(:store_bundler_credentials) { |user, token| stored << [user, token] }
+
+    @command.execute
+
+    assert_empty stored
+  end
+
+  test "execute warns about missing read:packages scope when the source rejects credentials" do
+    io = StringIO.new
+    logger = Logger.new(io)
+    command = Discharger::SetupRunner::Commands::GithubPackagesCommand.new(@config, @test_dir, logger)
+    stub_shell(gh_installed: true, authenticated: true,
+      gh_outputs: {["api", "user", "--jq", ".login"] => "octocat", ["auth", "token"] => "gho_secret"},
+      command: command)
+    command.define_singleton_method(:store_bundler_credentials) { |_user, _token| }
+    command.define_singleton_method(:credentials_valid?) { |_user, _token| false }
+
+    command.execute
+
+    assert_match(/read:packages/, io.string)
+    assert_match(/gh auth refresh/, io.string)
+  end
+
+  test "execute never logs the token" do
+    io = StringIO.new
+    logger = Logger.new(io)
+    command = Discharger::SetupRunner::Commands::GithubPackagesCommand.new(@config, @test_dir, logger)
+    stub_shell(gh_installed: true, authenticated: true,
+      gh_outputs: {["api", "user", "--jq", ".login"] => "octocat", ["auth", "token"] => "gho_secret"},
+      command: command)
+    command.define_singleton_method(:store_bundler_credentials) { |_user, _token| }
+    command.define_singleton_method(:credentials_valid?) { |_user, _token| true }
+
+    command.execute
+
+    refute_match(/gho_secret/, io.string)
+  end
+
+  test "execute warns when the source responds 401 to the credential probe" do
+    io = StringIO.new
+    with_stub_registry("401 Unauthorized") do |source|
+      command = probing_command(io, source)
+      command.execute
+    end
+
+    assert_match(/read:packages/, io.string)
+  end
+
+  test "execute reports success when the source accepts the credential probe" do
+    io = StringIO.new
+    with_stub_registry("200 OK") do |source|
+      command = probing_command(io, source)
+      command.execute
+    end
+
+    assert_match(/Configured bundler credentials/, io.string)
+    refute_match(/read:packages/, io.string)
+  end
+
+  test "execute treats an unreachable source as unverifiable, not invalid" do
+    io = StringIO.new
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    server.close
+    command = probing_command(io, "http://127.0.0.1:#{port}/example")
+
+    command.execute
+
+    assert_match(/Configured bundler credentials/, io.string)
+    refute_match(/read:packages/, io.string)
+  end
+
+  test "command is registered as github_packages" do
+    require "discharger/setup_runner/command_registry"
+    assert_equal Discharger::SetupRunner::Commands::GithubPackagesCommand,
+      Discharger::SetupRunner::CommandRegistry.get("github_packages")
+  end
+
+  private
+
+  # A command with real credential probing against the given source;
+  # everything before the probe is stubbed to succeed.
+  def probing_command(io, source)
+    config = Discharger::SetupRunner::Configuration.new
+    config.github_packages = Discharger::SetupRunner::GithubPackagesConfig.new.tap { |g| g.source = source }
+    command = Discharger::SetupRunner::Commands::GithubPackagesCommand.new(config, @test_dir, Logger.new(io))
+    stub_shell(gh_installed: true, authenticated: true,
+      gh_outputs: {["api", "user", "--jq", ".login"] => "octocat", ["auth", "token"] => "gho_secret"},
+      command: command)
+    command.define_singleton_method(:store_bundler_credentials) { |_user, _token| }
+    command
+  end
+
+  # Minimal one-request HTTP server so the probe hits a real socket.
+  def with_stub_registry(status_line)
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    thread = Thread.new do
+      client = server.accept
+      while (line = client.gets) && line != "\r\n"; end
+      client.write "HTTP/1.1 #{status_line}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+      client.close
+    end
+    yield "http://127.0.0.1:#{port}/example"
+  ensure
+    thread&.kill
+    server&.close
+  end
+
+  def stub_shell(gh_installed:, authenticated:, gh_outputs:, command: @command)
+    command.define_singleton_method(:system_quiet) do |*args|
+      case args.join(" ")
+      when "which gh" then gh_installed
+      when "gh auth status" then authenticated
+      else false
+      end
+    end
+    command.define_singleton_method(:gh) { |*args| gh_outputs[args] }
+  end
+end

--- a/test/setup_runner/configuration_test.rb
+++ b/test/setup_runner/configuration_test.rb
@@ -11,6 +11,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "Application", config.app_name
     assert_instance_of Discharger::SetupRunner::DatabaseConfig, config.database
     assert_nil config.redis
+    assert_nil config.github_packages
     assert_equal [], config.services
     assert_equal [], config.steps
     assert_equal [], config.custom_steps
@@ -29,6 +30,8 @@ class ConfigurationTest < ActiveSupport::TestCase
         port: 6380
         name: my-redis
         version: "7.0"
+      github_packages:
+        source: "https://rubygems.pkg.github.com/example"
       services:
         - elasticsearch
         - rabbitmq
@@ -55,6 +58,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal 6380, config.redis.port
     assert_equal "my-redis", config.redis.name
     assert_equal "7.0", config.redis.version
+    assert_equal "https://rubygems.pkg.github.com/example", config.github_packages.source
     assert_equal ["elasticsearch", "rabbitmq"], config.services
     assert_equal ["brew", "bundler"], config.steps
     assert_equal [{"name" => "custom_task", "command" => "echo \"custom\""}], config.custom_steps
@@ -79,6 +83,8 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "14", config.database.version
     # Redis not configured in YAML, so should be nil
     assert_nil config.redis
+    # GitHub Packages not configured in YAML, so should be nil
+    assert_nil config.github_packages
   end
 
   test "handles empty YAML file" do


### PR DESCRIPTION
## Why

Apps with private GitHub Packages gem sources (Qualify, FORGE before SOFware/FORGE#8287) have carried a shared token embedded in the Gemfile. It leaks in the repo and goes stale, breaking `bundle install` for everyone at once. FORGE moved to per-developer credentials from the GitHub CLI; this brings the same flow to every app that runs setup through Discharger.

## Summary

- New `github_packages` setup step: reads the developer's username and token from `gh`, stores them with `bundle config set --local` for the configured source. Runs before `bundler` in the steps list.
- Configured via a new `github_packages.source` entry in `setup.yml`; the step is skipped when not configured.
- Non-fatal by design: missing `gh`, failed login, or unreadable credentials warn and continue rather than failing setup.
- After storing, a probe of the source's compact index catches tokens without the `read:packages` scope and tells the developer to run `gh auth refresh -s read:packages` — without that, the failure is a cryptic 403 at install time.
- The credential write goes through `Open3` directly rather than `system!` so the token never reaches the spinner display or the debug log.

Note for consumers: bundler only applies configured credentials when the source URL has no embedded userinfo, so each app must also drop the token from its Gemfile `source` line for this to take effect.