### PR TITLE
Fix github_packages step never running when configured

### DIFF
--- a/lib/discharger/setup_runner/command_factory.rb
+++ b/lib/discharger/setup_runner/command_factory.rb
@@ -28,6 +28,9 @@ module Discharger
 
         # Create built-in commands from steps
         if config.steps.any?
+          # Only reachable here: the else branch schedules every registered
+          # command, so github_packages can never be missing from it.
+          warn_unscheduled_github_packages
           config.steps.each do |step|
             command = create_command(step)
             commands << command if command
@@ -50,6 +53,19 @@ module Discharger
         end
 
         commands
+      end
+
+      private
+
+      # A github_packages block with no matching step is inert, and the only
+      # symptom is bundler failing against the private source. Say so instead.
+      def warn_unscheduled_github_packages
+        source = config.github_packages&.source
+        return if source.to_s.empty?
+        return if config.steps.map(&:to_s).include?("github_packages")
+
+        logger&.warn "github_packages is configured but missing from steps; " \
+          "credentials will not be stored and bundler may fail for #{source}"
       end
     end
   end

--- a/lib/discharger/setup_runner/commands/github_packages_command.rb
+++ b/lib/discharger/setup_runner/commands/github_packages_command.rb
@@ -48,7 +48,7 @@ module Discharger
         protected
 
         def source
-          config.github_packages&.source if config.respond_to?(:github_packages)
+          config.github_packages&.source
         end
 
         def gh_installed?

--- a/lib/generators/discharger/install/templates/setup.yml
+++ b/lib/generators/discharger/install/templates/setup.yml
@@ -49,6 +49,8 @@ steps:
   - brew
   - asdf
   - git
+  # Uncomment with the github_packages block above. Must precede bundler.
+  # - github_packages
   - bundler
   - yarn
   - config

--- a/test/setup_runner/commands/github_packages_command_test.rb
+++ b/test/setup_runner/commands/github_packages_command_test.rb
@@ -3,6 +3,7 @@ require "setup_runner_test_helper"
 require "discharger/setup_runner/configuration"
 require "discharger/setup_runner/commands/github_packages_command"
 require "logger"
+require "open3"
 require "socket"
 
 class GithubPackagesCommandTest < ActiveSupport::TestCase
@@ -113,6 +114,25 @@ class GithubPackagesCommandTest < ActiveSupport::TestCase
     refute_match(/gho_secret/, io.string)
   end
 
+  test "store_bundler_credentials writes the credentials to the local bundler config" do
+    calls = stub_capture3(success: true) do
+      @command.send(:store_bundler_credentials, "octocat", "gho_secret")
+    end
+
+    assert_equal [["bundle", "config", "set", "--local", SOURCE, "octocat:gho_secret"]], calls
+  end
+
+  test "store_bundler_credentials raises without leaking the token when bundle config fails" do
+    error = assert_raises(RuntimeError) do
+      stub_capture3(success: false, stderr: "could not write config") do
+        @command.send(:store_bundler_credentials, "octocat", "gho_secret")
+      end
+    end
+
+    assert_match(/could not write config/, error.message)
+    refute_match(/gho_secret/, error.message)
+  end
+
   test "execute warns when the source responds 401 to the credential probe" do
     io = StringIO.new
     with_stub_registry("401 Unauthorized") do |source|
@@ -154,6 +174,23 @@ class GithubPackagesCommandTest < ActiveSupport::TestCase
   end
 
   private
+
+  # Captures the argv Open3.capture3 is called with so the credential write
+  # can be asserted without shelling out to a real bundler.
+  def stub_capture3(success:, stderr: "")
+    calls = []
+    original = Open3.method(:capture3)
+    status = Object.new
+    status.define_singleton_method(:success?) { success }
+    Open3.define_singleton_method(:capture3) do |*args|
+      calls << args
+      ["", stderr, status]
+    end
+    yield
+    calls
+  ensure
+    Open3.define_singleton_method(:capture3, original)
+  end
 
   # A command with real credential probing against the given source;
   # everything before the probe is stubbed to succeed.

--- a/test/setup_runner/integration_test.rb
+++ b/test/setup_runner/integration_test.rb
@@ -33,6 +33,57 @@ class SetupRunnerIntegrationTest < ActiveSupport::TestCase
     assert_file_exists("test_output.txt")
   end
 
+  test "warns when github_packages is configured but missing from steps" do
+    create_file("setup.yml", <<~YAML)
+      app_name: TestApp
+      github_packages:
+        source: "https://rubygems.pkg.github.com/example"
+      steps:
+        - env
+    YAML
+
+    io = StringIO.new
+    capture_output do
+      Discharger::SetupRunner.run("setup.yml", Logger.new(io))
+    end
+
+    assert_match(/github_packages is configured but missing from steps/, io.string)
+    assert_match(%r{https://rubygems\.pkg\.github\.com/example}, io.string)
+  end
+
+  test "stays quiet when github_packages is configured and scheduled" do
+    create_file("setup.yml", <<~YAML)
+      app_name: TestApp
+      github_packages:
+        source: "https://rubygems.pkg.github.com/example"
+      steps:
+        - github_packages
+        - env
+    YAML
+
+    io = StringIO.new
+    capture_output do
+      Discharger::SetupRunner.run("setup.yml", Logger.new(io))
+    end
+
+    refute_match(/missing from steps/, io.string)
+  end
+
+  test "stays quiet when github_packages is not configured at all" do
+    create_file("setup.yml", <<~YAML)
+      app_name: TestApp
+      steps:
+        - env
+    YAML
+
+    io = StringIO.new
+    capture_output do
+      Discharger::SetupRunner.run("setup.yml", Logger.new(io))
+    end
+
+    refute_match(/missing from steps/, io.string)
+  end
+
   test "allows programmatic configuration" do
     Discharger::SetupRunner.configure do |config|
       config.app_name = "ProgrammaticApp"


### PR DESCRIPTION
Follow-up to #231.

Configuring `github_packages` in `setup.yml` silently did nothing unless the step was also listed in `steps:`, and the only symptom was `bundle install` failing against the private source. The factory now warns when a source is configured but the step is absent.

Also covers `store_bundler_credentials`, which was stubbed in every test that reached it, and drops a `respond_to?` guard that can no longer be false.

#234 is stacked on this and fixes the related `steps: []` ordering bug.
