### PR TITLE
Make the setup runner's no-steps fallback order explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ steps:
   - yarn
 ```
 
-Leave the array empty or omit it entirely to run all available steps.
+Leave the array empty or omit it entirely to run all available steps, in the order listed above. Custom commands registered through `Discharger::SetupRunner.register_command` run last.
 
 ### Adding Custom Commands
 

--- a/lib/discharger/setup_runner/command_factory.rb
+++ b/lib/discharger/setup_runner/command_factory.rb
@@ -37,7 +37,7 @@ module Discharger
           end
         else
           # If no steps specified, create all registered commands
-          CommandRegistry.names.each do |name|
+          CommandRegistry.ordered_names.each do |name|
             command = create_command(name)
             commands << command if command
           end

--- a/lib/discharger/setup_runner/command_registry.rb
+++ b/lib/discharger/setup_runner/command_registry.rb
@@ -3,6 +3,24 @@
 module Discharger
   module SetupRunner
     class CommandRegistry
+      # The order built-in steps run in when setup.yml configures no steps.
+      # Registration order cannot be relied on here: it comes from enumerating
+      # Commands.constants, which shifts with require order. Credentials and
+      # toolchains have to be in place before bundler resolves gems.
+      DEFAULT_ORDER = %w[
+        brew
+        asdf
+        git
+        github_packages
+        bundler
+        yarn
+        config
+        docker
+        pg_tools
+        env
+        database
+      ].freeze
+
       class << self
         def register(name, command_class)
           commands[name.to_s] = command_class
@@ -18,6 +36,12 @@ module Discharger
 
         def names
           commands.keys
+        end
+
+        # Registered names in pipeline order, with anything outside
+        # DEFAULT_ORDER (custom commands) appended in registration order.
+        def ordered_names
+          (DEFAULT_ORDER & names) + (names - DEFAULT_ORDER)
         end
 
         def clear

--- a/test/setup_runner/command_registry_test.rb
+++ b/test/setup_runner/command_registry_test.rb
@@ -109,4 +109,23 @@ class CommandRegistryTest < ActiveSupport::TestCase
     assert_empty registry.all
     assert_empty registry.names
   end
+
+  test "ordered_names sorts registered commands into pipeline order" do
+    registry = Discharger::SetupRunner::CommandRegistry
+
+    registry.register("bundler", TestCommand)
+    registry.register("github_packages", TestCommand)
+    registry.register("brew", TestCommand)
+
+    assert_equal %w[brew github_packages bundler], registry.ordered_names
+  end
+
+  test "ordered_names appends commands with no default position" do
+    registry = Discharger::SetupRunner::CommandRegistry
+
+    registry.register("deploy_keys", TestCommand)
+    registry.register("bundler", AnotherTestCommand)
+
+    assert_equal %w[bundler deploy_keys], registry.ordered_names
+  end
 end

--- a/test/setup_runner/commands/github_packages_command_test.rb
+++ b/test/setup_runner/commands/github_packages_command_test.rb
@@ -173,6 +173,14 @@ class GithubPackagesCommandTest < ActiveSupport::TestCase
       Discharger::SetupRunner::CommandRegistry.get("github_packages")
   end
 
+  test "github_packages runs before bundler when no steps are configured" do
+    require "discharger/setup_runner/command_registry"
+    names = Discharger::SetupRunner::CommandRegistry.ordered_names
+
+    assert_operator names.index("github_packages"), :<, names.index("bundler"),
+      "credentials must be stored before bundler installs from the private source"
+  end
+
   private
 
   # Captures the argv Open3.capture3 is called with so the credential write


### PR DESCRIPTION
Stacked on #233.

With `steps: []`, `CommandFactory` ran every registered command in `CommandRegistry.names` order, which comes from enumerating `Commands.constants` and shifts with require order. A test asserting `github_packages` precedes `bundler` passed standalone and failed under the full suite, where the order starts `["bundler", "config", "pg_tools", ...]` — credentials written after `bundle install` had already failed.

`DEFAULT_ORDER` makes the pipeline explicit; registered custom commands are appended last.

Note: `ordered_names` also appends the registry's `custom` entry, which `create_command` cannot construct and warns about on every `steps: []` run. Pre-existing, not touched here.
