### PR TITLE
Stop registering CustomCommand as a step

### DIFF
--- a/lib/discharger/setup_runner/command_registry.rb
+++ b/lib/discharger/setup_runner/command_registry.rb
@@ -65,6 +65,9 @@ module Discharger
             command_class = Commands.const_get(const_name)
             next unless command_class < Commands::BaseCommand
             next if command_class == Commands::BaseCommand
+            # Not schedulable by name: it takes a step_config argument and is
+            # instantiated by CommandFactory from custom_steps entries.
+            next if command_class == Commands::CustomCommand
 
             # Convert class name to command name (e.g., AsdfCommand -> asdf)
             command_name = const_name.to_s.sub(/Command$/, "").gsub(/([A-Z])/, '_\1').downcase.sub(/^_/, "")

--- a/test/setup_runner/command_factory_test.rb
+++ b/test/setup_runner/command_factory_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+require "discharger/setup_runner/configuration"
+require "discharger/setup_runner/command_factory"
+require "logger"
+require "stringio"
+
+class CommandFactoryTest < ActiveSupport::TestCase
+  test "constructs every registered command without warnings when no steps are configured" do
+    config = Discharger::SetupRunner::Configuration.new
+    io = StringIO.new
+    factory = Discharger::SetupRunner::CommandFactory.new(config, Dir.pwd, Logger.new(io))
+
+    commands = factory.create_all_commands
+
+    assert_equal Discharger::SetupRunner::CommandRegistry.ordered_names.size, commands.size
+    refute_match(/Failed to create command/, io.string)
+  end
+end

--- a/test/setup_runner/command_registry_test.rb
+++ b/test/setup_runner/command_registry_test.rb
@@ -120,6 +120,17 @@ class CommandRegistryTest < ActiveSupport::TestCase
     assert_equal %w[brew github_packages bundler], registry.ordered_names
   end
 
+  test "load_commands does not register the custom placeholder" do
+    registry = Discharger::SetupRunner::CommandRegistry
+
+    registry.load_commands
+
+    assert_includes registry.names, "bundler"
+    refute_includes registry.names, "custom",
+      "CustomCommand needs a step_config and is built from custom_steps; " \
+      "registering it by name only produces construction failures"
+  end
+
   test "ordered_names appends commands with no default position" do
     registry = Discharger::SetupRunner::CommandRegistry
 

--- a/test/setup_runner/command_registry_test.rb
+++ b/test/setup_runner/command_registry_test.rb
@@ -131,6 +131,16 @@ class CommandRegistryTest < ActiveSupport::TestCase
       "registering it by name only produces construction failures"
   end
 
+  test "DEFAULT_ORDER stays in sync with the auto-registered built-ins" do
+    registry = Discharger::SetupRunner::CommandRegistry
+
+    registry.load_commands
+
+    assert_equal registry::DEFAULT_ORDER.sort, registry.names.sort,
+      "a built-in command missing from DEFAULT_ORDER would silently run " \
+      "after database, intermixed with custom commands"
+  end
+
   test "ordered_names appends commands with no default position" do
     registry = Discharger::SetupRunner::CommandRegistry
 

--- a/test/setup_runner/commands/github_packages_command_test.rb
+++ b/test/setup_runner/commands/github_packages_command_test.rb
@@ -177,6 +177,8 @@ class GithubPackagesCommandTest < ActiveSupport::TestCase
     require "discharger/setup_runner/command_registry"
     names = Discharger::SetupRunner::CommandRegistry.ordered_names
 
+    assert_includes names, "github_packages"
+    assert_includes names, "bundler"
     assert_operator names.index("github_packages"), :<, names.index("bundler"),
       "credentials must be stored before bundler installs from the private source"
   end


### PR DESCRIPTION
Stacked on #234, addressing the wart disclosed in its description.

`load_commands` globs `commands/*_command.rb` and auto-registers every `BaseCommand` subclass, which swept in `CustomCommand`. But `CustomCommand.new` takes a fourth `step_config` argument, so `create_command("custom")` always raised `ArgumentError` and every `steps: []` run logged `Failed to create command custom: wrong number of arguments`. Custom commands were never actually created through the registry — `CommandFactory` builds them directly from `custom_steps` — so the entry was pure noise.

`load_commands` now skips `CustomCommand` during auto-registration. `ordered_names` needs no change: with the placeholder gone, the appended tail is exactly the commands registered through `Discharger::SetupRunner.register_command`.

One behavior change worth noting: a literal `- custom` entry in `steps:` previously produced the "Failed to create command" warning; it is now silently ignored like any other unknown step name. Warning on unknown step names generally (the `github_packages` class of problem from #233) would be a separate follow-up.