### PR TITLE
Allow scheduling named custom steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,26 @@ Each custom step can include:
 - `description` - A description shown during setup
 - `command` - The command to execute
 - `condition` - An optional Ruby expression that must evaluate to true for the command to run
+- `name` - An optional name that lets the step be scheduled in the `steps` list
+
+Custom steps run after the built-in steps, in the order listed. To run one
+earlier, give it a `name` and list that name in `steps`:
+
+```yaml
+custom_steps:
+  - name: import_certs
+    description: "Import development certificates"
+    command: "bin/import-certs"
+
+steps:
+  - brew
+  - import_certs  # runs between brew and bundler
+  - bundler
+```
+
+A named step listed in `steps` runs only at that position; named steps that
+are not listed keep the default run-last behavior. A name that collides with
+a built-in step resolves to the built-in, and a warning is logged.
 
 ### Creating Custom Command Classes
 

--- a/lib/discharger/setup_runner/command_factory.rb
+++ b/lib/discharger/setup_runner/command_factory.rb
@@ -25,7 +25,6 @@ module Discharger
 
       def create_all_commands
         commands = []
-        named_custom = named_custom_steps
         scheduled = []
 
         # Create built-in and named custom commands from steps
@@ -33,13 +32,15 @@ module Discharger
           # Only reachable here: the else branch schedules every registered
           # command, so github_packages can never be missing from it.
           warn_unscheduled_github_packages
+          named_custom = named_custom_steps
           config.steps.each do |step|
             name = step.to_s
-            if (command = create_command(name))
+            if CommandRegistry.get(name)
               if named_custom.key?(name)
                 logger&.warn "custom step name #{name.inspect} is shadowed by a built-in command; the built-in will run"
               end
-              commands << command
+              command = create_command(name)
+              commands << command if command
             elsif (step_config = named_custom[name])
               scheduled << step_config
               commands << build_custom_command(step_config)

--- a/lib/discharger/setup_runner/command_factory.rb
+++ b/lib/discharger/setup_runner/command_factory.rb
@@ -25,15 +25,27 @@ module Discharger
 
       def create_all_commands
         commands = []
+        named_custom = named_custom_steps
+        scheduled = []
 
-        # Create built-in commands from steps
+        # Create built-in and named custom commands from steps
         if config.steps.any?
           # Only reachable here: the else branch schedules every registered
           # command, so github_packages can never be missing from it.
           warn_unscheduled_github_packages
           config.steps.each do |step|
-            command = create_command(step)
-            commands << command if command
+            name = step.to_s
+            if (command = create_command(name))
+              if named_custom.key?(name)
+                logger&.warn "custom step name #{name.inspect} is shadowed by a built-in command; the built-in will run"
+              end
+              commands << command
+            elsif (step_config = named_custom[name])
+              scheduled << step_config
+              commands << build_custom_command(step_config)
+            else
+              logger&.warn "unknown step #{name.inspect}; not a built-in or named custom step"
+            end
           end
         else
           # If no steps specified, create all registered commands
@@ -43,12 +55,11 @@ module Discharger
           end
         end
 
-        # Create custom commands
+        # Create the remaining custom commands
         if config.respond_to?(:custom_steps) && config.custom_steps.any?
-          require_relative "commands/custom_command"
           config.custom_steps.each do |step_config|
-            command = Commands::CustomCommand.new(config, app_root, logger, step_config)
-            commands << command
+            next if scheduled.any? { |s| s.equal?(step_config) }
+            commands << build_custom_command(step_config)
           end
         end
 
@@ -56,6 +67,29 @@ module Discharger
       end
 
       private
+
+      # Custom steps with a "name" key can be scheduled by that name in
+      # steps:. First entry wins a contested name; later duplicates keep the
+      # default run-last behavior.
+      def named_custom_steps
+        return {} unless config.respond_to?(:custom_steps)
+
+        config.custom_steps.each_with_object({}) do |step_config, named|
+          name = step_config["name"].to_s
+          next if name.empty?
+
+          if named.key?(name)
+            logger&.warn "duplicate custom step name #{name.inspect}; only the first entry can be scheduled"
+            next
+          end
+          named[name] = step_config
+        end
+      end
+
+      def build_custom_command(step_config)
+        require_relative "commands/custom_command"
+        Commands::CustomCommand.new(config, app_root, logger, step_config)
+      end
 
       # A github_packages block with no matching step is inert, and the only
       # symptom is bundler failing against the private source. Say so instead.

--- a/lib/generators/discharger/install/templates/setup.yml
+++ b/lib/generators/discharger/install/templates/setup.yml
@@ -62,6 +62,11 @@ steps:
 #   - pg_tools
 
 # Custom commands for application-specific setup (run AFTER Rails loads)
+# Steps run last by default. Give a step a name and list it in steps: above
+# to run it earlier, e.g.:
+#   - name: import_certs
+#     description: "Import development certificates"
+#     command: "bin/import-certs"
 custom_steps:
   - description: "Seed application data"
     command: "bin/rails db:seed"

--- a/test/setup_runner/command_factory_test.rb
+++ b/test/setup_runner/command_factory_test.rb
@@ -5,6 +5,94 @@ require "logger"
 require "stringio"
 
 class CommandFactoryTest < ActiveSupport::TestCase
+  test "schedules a named custom step at its position in steps" do
+    config = config_with(
+      steps: %w[git seed bundler],
+      custom_steps: [
+        {"name" => "seed", "description" => "Seed data", "command" => "true"}
+      ]
+    )
+
+    commands = factory(config).create_all_commands
+
+    assert_equal [
+      Discharger::SetupRunner::Commands::GitCommand,
+      Discharger::SetupRunner::Commands::CustomCommand,
+      Discharger::SetupRunner::Commands::BundlerCommand
+    ], commands.map(&:class)
+    assert_equal 1, commands.count { |c| c.is_a?(Discharger::SetupRunner::Commands::CustomCommand) },
+      "a scheduled custom step must not also be appended at the end"
+  end
+
+  test "appends unnamed and unscheduled named custom steps last" do
+    config = config_with(
+      steps: %w[git],
+      custom_steps: [
+        {"name" => "docs", "description" => "Build docs", "command" => "true"},
+        {"description" => "Anonymous", "command" => "true"}
+      ]
+    )
+
+    commands = factory(config).create_all_commands
+
+    assert_equal Discharger::SetupRunner::Commands::GitCommand, commands[0].class
+    assert_equal ["Build docs", "Anonymous"], commands[1..].map(&:description)
+  end
+
+  test "warns on unknown step names" do
+    config = config_with(steps: %w[git sed], custom_steps: [
+      {"name" => "seed", "description" => "Seed data", "command" => "true"}
+    ])
+    io = StringIO.new
+
+    factory(config, io).create_all_commands
+
+    assert_match(/unknown step "sed"/, io.string)
+  end
+
+  test "warns and keeps the first custom step when names collide" do
+    config = config_with(
+      steps: %w[seed],
+      custom_steps: [
+        {"name" => "seed", "description" => "First", "command" => "true"},
+        {"name" => "seed", "description" => "Second", "command" => "true"}
+      ]
+    )
+    io = StringIO.new
+
+    commands = factory(config, io).create_all_commands
+
+    assert_match(/duplicate custom step name "seed"/, io.string)
+    assert_equal ["First", "Second"], commands.map(&:description),
+      "the first entry takes the scheduled slot; the duplicate still runs last"
+  end
+
+  test "warns when a custom step name is shadowed by a built-in" do
+    config = config_with(
+      steps: %w[bundler],
+      custom_steps: [
+        {"name" => "bundler", "description" => "Fake bundler", "command" => "true"}
+      ]
+    )
+    io = StringIO.new
+
+    commands = factory(config, io).create_all_commands
+
+    assert_match(/custom step name "bundler" is shadowed by a built-in/, io.string)
+    assert_equal Discharger::SetupRunner::Commands::BundlerCommand, commands.first.class
+  end
+
+  test "empty steps still runs every built-in then custom steps last" do
+    config = config_with(steps: [], custom_steps: [
+      {"name" => "seed", "description" => "Seed data", "command" => "true"}
+    ])
+
+    commands = factory(config).create_all_commands
+
+    assert_equal Discharger::SetupRunner::CommandRegistry.ordered_names.size + 1, commands.size
+    assert_equal "Seed data", commands.last.description
+  end
+
   test "constructs every registered command without warnings when no steps are configured" do
     config = Discharger::SetupRunner::Configuration.new
     io = StringIO.new
@@ -14,5 +102,18 @@ class CommandFactoryTest < ActiveSupport::TestCase
 
     assert_equal Discharger::SetupRunner::CommandRegistry.ordered_names.size, commands.size
     refute_match(/Failed to create command/, io.string)
+  end
+
+  private
+
+  def config_with(steps:, custom_steps: [])
+    config = Discharger::SetupRunner::Configuration.new
+    config.steps = steps
+    config.custom_steps = custom_steps
+    config
+  end
+
+  def factory(config, io = StringIO.new)
+    Discharger::SetupRunner::CommandFactory.new(config, Dir.pwd, Logger.new(io))
   end
 end

--- a/test/setup_runner/command_factory_test.rb
+++ b/test/setup_runner/command_factory_test.rb
@@ -82,6 +82,38 @@ class CommandFactoryTest < ActiveSupport::TestCase
     assert_equal Discharger::SetupRunner::Commands::BundlerCommand, commands.first.class
   end
 
+  test "does not warn about duplicate names when no steps are configured" do
+    config = config_with(steps: [], custom_steps: [
+      {"name" => "seed", "description" => "First", "command" => "true"},
+      {"name" => "seed", "description" => "Second", "command" => "true"}
+    ])
+    io = StringIO.new
+
+    factory(config, io).create_all_commands
+
+    refute_match(/duplicate custom step name/, io.string,
+      "nothing resolves by name without steps, so the warning is noise")
+  end
+
+  test "does not mislabel a failing registered command as unknown" do
+    require "discharger/setup_runner"
+    broken = Class.new(Discharger::SetupRunner::Commands::BaseCommand) do
+      def initialize(*)
+        raise "boom"
+      end
+    end
+    Discharger::SetupRunner.register_command("broken", broken)
+    config = config_with(steps: %w[broken])
+    io = StringIO.new
+
+    factory(config, io).create_all_commands
+
+    assert_match(/Failed to create command broken/, io.string)
+    refute_match(/unknown step/, io.string)
+  ensure
+    Discharger::SetupRunner.unregister_command("broken")
+  end
+
   test "empty steps still runs every built-in then custom steps last" do
     config = config_with(steps: [], custom_steps: [
       {"name" => "seed", "description" => "Seed data", "command" => "true"}

--- a/test/setup_runner/integration_test.rb
+++ b/test/setup_runner/integration_test.rb
@@ -101,6 +101,31 @@ class SetupRunnerIntegrationTest < ActiveSupport::TestCase
     refute_match(/missing from steps/, io.string)
   end
 
+  test "runs a named custom step at its scheduled position" do
+    create_file("setup.yml", <<~YAML)
+      app_name: TestApp
+      steps:
+        - prepare
+        - env
+      custom_steps:
+        - name: prepare
+          description: "Prepare marker"
+          command: "touch marker.txt"
+    YAML
+    create_file(".env.example", "TEST_VAR=example")
+
+    out = nil
+    with_output_enabled do
+      out, _ = capture_output do
+        Discharger::SetupRunner.run("setup.yml", Logger.new(StringIO.new))
+      end
+    end
+
+    assert_file_exists("marker.txt")
+    assert_operator out.index("Prepare marker"), :<, out.index("Setup environment file"),
+      "the named custom step must run at its scheduled position, not last"
+  end
+
   test "allows programmatic configuration" do
     Discharger::SetupRunner.configure do |config|
       config.app_name = "ProgrammaticApp"


### PR DESCRIPTION
Stacked on #236.

YAML-defined `custom_steps` were anonymous and always ran after every built-in; nothing in `steps:` could reference them, so there was no way to run an app-specific command before, say, `bundler`. Custom steps now take an optional `name:` key, and that name can be listed in `steps:` to run the step at that position.

Resolution rules in `CommandFactory#create_all_commands`:

- A `steps:` entry resolves to the registry first (built-ins and `register_command` classes), then to a named custom step. A custom name shadowed by a built-in logs a warning and the built-in runs.
- A named custom step listed in `steps:` runs only at that position; unnamed or unlisted custom steps keep the run-last behavior, so existing configs are unchanged.
- Unknown `steps:` entries now log a warning instead of being silently skipped — the generalization of the `github_packages` problem from #233. Duplicate custom step names warn and the first entry keeps the name.

Covered by factory unit tests for each rule, an integration test asserting a named step executes at its scheduled position, and README/template docs.