### PR TITLE
Guard the default step order against drift

### DIFF
--- a/test/setup_runner/command_registry_test.rb
+++ b/test/setup_runner/command_registry_test.rb
@@ -131,6 +131,16 @@ class CommandRegistryTest < ActiveSupport::TestCase
       "registering it by name only produces construction failures"
   end
 
+  test "DEFAULT_ORDER stays in sync with the auto-registered built-ins" do
+    registry = Discharger::SetupRunner::CommandRegistry
+
+    registry.load_commands
+
+    assert_equal registry::DEFAULT_ORDER.sort, registry.names.sort,
+      "a built-in command missing from DEFAULT_ORDER would silently run " \
+      "after database, intermixed with custom commands"
+  end
+
   test "ordered_names appends commands with no default position" do
     registry = Discharger::SetupRunner::CommandRegistry
 

--- a/test/setup_runner/commands/github_packages_command_test.rb
+++ b/test/setup_runner/commands/github_packages_command_test.rb
@@ -177,6 +177,8 @@ class GithubPackagesCommandTest < ActiveSupport::TestCase
     require "discharger/setup_runner/command_registry"
     names = Discharger::SetupRunner::CommandRegistry.ordered_names
 
+    assert_includes names, "github_packages"
+    assert_includes names, "bundler"
     assert_operator names.index("github_packages"), :<, names.index("bundler"),
       "credentials must be stored before bundler installs from the private source"
   end


### PR DESCRIPTION
Stacked on #236 (sibling of #237). Addresses the two remaining review findings on #234.

- A new registry test asserts `DEFAULT_ORDER` matches the auto-registered built-ins exactly. Without it, a contributor adding a new `*_command.rb` file gets it auto-registered but silently appended after `database` in the no-steps path, intermixed with custom commands — contradicting the README and potentially recreating the credentials-after-bundler class of bug. The guard turns that into an immediate, readable test failure (verified: it fails against main's registry, where the stray `custom` entry still exists — which is why this stacks on #236).
- The `github_packages`-before-`bundler` ordering test now asserts both names are present before comparing indexes, so a missing name produces a clear assertion failure instead of `NoMethodError: undefined method '<' for nil`.

Test-only change; full suite passes.