### PR TITLE
Wire the defaulted logger into the factory

### DIFF
--- a/lib/discharger/setup_runner/runner.rb
+++ b/lib/discharger/setup_runner/runner.rb
@@ -15,7 +15,7 @@ module Discharger
         @config = config
         @app_root = app_root || Dir.pwd
         @logger = logger || Logger.new($stdout)
-        @command_factory = CommandFactory.new(config, app_root, logger)
+        @command_factory = CommandFactory.new(config, @app_root, @logger)
       end
 
       def run

--- a/test/setup_runner/integration_test.rb
+++ b/test/setup_runner/integration_test.rb
@@ -51,6 +51,23 @@ class SetupRunnerIntegrationTest < ActiveSupport::TestCase
     assert_match(%r{https://rubygems\.pkg\.github\.com/example}, io.string)
   end
 
+  test "warns about unscheduled github_packages without an explicit logger" do
+    create_file("setup.yml", <<~YAML)
+      app_name: TestApp
+      github_packages:
+        source: "https://rubygems.pkg.github.com/example"
+      steps:
+        - env
+    YAML
+
+    out, _ = capture_output do
+      Discharger::SetupRunner.run("setup.yml")
+    end
+
+    assert_match(/github_packages is configured but missing from steps/, out,
+      "the warning must reach the default stdout logger, as bin/setup passes none")
+  end
+
   test "stays quiet when github_packages is configured and scheduled" do
     create_file("setup.yml", <<~YAML)
       app_name: TestApp

--- a/test/setup_runner/runner_test.rb
+++ b/test/setup_runner/runner_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+require "discharger/setup_runner"
+
+class SetupRunnerRunnerTest < ActiveSupport::TestCase
+  test "passes its defaulted logger and app_root to the command factory" do
+    config = Discharger::SetupRunner::Configuration.new
+    runner = Discharger::SetupRunner::Runner.new(config)
+
+    assert_same runner.logger, runner.command_factory.logger,
+      "warnings from the factory are lost when it gets the raw nil logger"
+    assert_same runner.app_root, runner.command_factory.app_root
+  end
+end


### PR DESCRIPTION
Fixes a review finding on #233: `Runner#initialize` passed its raw `logger` and `app_root` parameters — not the defaulted `@logger`/`@app_root` — to `CommandFactory.new`. The production `bin/setup` path calls `SetupRunner.run(config_path)` with no logger, so the factory's logger was nil and `logger&.warn` silently dropped every factory warning, including the unscheduled-github_packages warning #233 added. The existing integration tests passed only because they inject a logger explicitly.

The factory now receives the same defaulted logger and app_root the runner uses. Covered by a unit test asserting the runner and factory share the logger/app_root, and an integration test asserting the github_packages warning reaches stdout when no logger is passed — both failed before the fix (the integration test's captured stdout was empty).