### PR TITLE
Rework the unscheduled github_packages warning

### DIFF
--- a/lib/discharger/setup_runner/command_factory.rb
+++ b/lib/discharger/setup_runner/command_factory.rb
@@ -29,9 +29,6 @@ module Discharger
 
         # Create built-in and named custom commands from steps
         if config.steps.any?
-          # Only reachable here: the else branch schedules every registered
-          # command, so github_packages can never be missing from it.
-          warn_unscheduled_github_packages
           named_custom = named_custom_steps
           config.steps.each do |step|
             name = step.to_s
@@ -90,17 +87,6 @@ module Discharger
       def build_custom_command(step_config)
         require_relative "commands/custom_command"
         Commands::CustomCommand.new(config, app_root, logger, step_config)
-      end
-
-      # A github_packages block with no matching step is inert, and the only
-      # symptom is bundler failing against the private source. Say so instead.
-      def warn_unscheduled_github_packages
-        source = config.github_packages&.source
-        return if source.to_s.empty?
-        return if config.steps.map(&:to_s).include?("github_packages")
-
-        logger&.warn "github_packages is configured but missing from steps; " \
-          "credentials will not be stored and bundler may fail for #{source}"
       end
     end
   end

--- a/lib/discharger/setup_runner/commands/github_packages_command.rb
+++ b/lib/discharger/setup_runner/commands/github_packages_command.rb
@@ -22,13 +22,24 @@ module Discharger
           source = config.github_packages&.source
           return if source.to_s.empty?
           if config.respond_to?(:custom_steps) &&
-              config.custom_steps.any? { |step| step["command"].to_s.include?(source) }
+              config.custom_steps.any? { |step| step_handles_source?(step, source) }
             return
           end
 
           "github_packages is configured but missing from steps; " \
             "credentials will not be stored and bundler may fail for #{source}"
         end
+
+        # A referencing step only counts as handling credentials when it will
+        # actually run: CustomCommand skips itself when its condition is
+        # false, storing nothing on this run.
+        def self.step_handles_source?(step, source)
+          return false unless step["command"].to_s.include?(source)
+
+          require_relative "../condition_evaluator"
+          ConditionEvaluator.evaluate(step["condition"])
+        end
+        private_class_method :step_handles_source?
 
         def execute
           unless gh_installed?

--- a/lib/discharger/setup_runner/commands/github_packages_command.rb
+++ b/lib/discharger/setup_runner/commands/github_packages_command.rb
@@ -10,6 +10,26 @@ module Discharger
       # Credentials are written to the app's .bundle/config — keep .bundle
       # gitignored. Run this step before "bundler" in setup.yml.
       class GithubPackagesCommand < BaseCommand
+        # A configured source with nothing scheduled to store its credentials
+        # is inert, and the only symptom is bundler failing against the
+        # private source. The Runner surfaces this before executing commands.
+        # Guarded for duck-typed configs passed to the public Runner API, and
+        # quiet when a custom step's command references the source (assumed
+        # to handle credentials itself).
+        def self.unscheduled_warning(config)
+          return unless config.respond_to?(:github_packages)
+
+          source = config.github_packages&.source
+          return if source.to_s.empty?
+          if config.respond_to?(:custom_steps) &&
+              config.custom_steps.any? { |step| step["command"].to_s.include?(source) }
+            return
+          end
+
+          "github_packages is configured but missing from steps; " \
+            "credentials will not be stored and bundler may fail for #{source}"
+        end
+
         def execute
           unless gh_installed?
             log "GitHub CLI (gh) not found; skipping. Install gh and rerun setup or `bundle install` may fail for #{source}"

--- a/lib/discharger/setup_runner/runner.rb
+++ b/lib/discharger/setup_runner/runner.rb
@@ -25,6 +25,8 @@ module Discharger
           puts Rainbow("=" * 50).blue
         end
 
+        warn_unscheduled_commands
+
         FileUtils.chdir app_root do
           execute_commands
         end
@@ -74,6 +76,18 @@ module Discharger
 
       def commands
         @commands ||= command_factory.create_all_commands
+      end
+
+      # Checked at run time, after the customization block, so commands
+      # scheduled through add_command/insert_command_* count as scheduled.
+      def warn_unscheduled_commands
+        CommandRegistry.all.each do |klass|
+          next unless klass.respond_to?(:unscheduled_warning)
+          next if commands.any? { |command| command.is_a?(klass) }
+
+          message = klass.unscheduled_warning(config)
+          logger.warn message if message
+        end
       end
 
       def execute_commands

--- a/test/setup_runner/command_factory_test.rb
+++ b/test/setup_runner/command_factory_test.rb
@@ -136,6 +136,15 @@ class CommandFactoryTest < ActiveSupport::TestCase
     refute_match(/Failed to create command/, io.string)
   end
 
+  test "tolerates config objects without a github_packages accessor" do
+    duck = Struct.new(:steps, :custom_steps).new(%w[env], [])
+    factory = Discharger::SetupRunner::CommandFactory.new(duck, Dir.pwd, Logger.new(StringIO.new))
+
+    commands = factory.create_all_commands
+
+    assert_equal 1, commands.size
+  end
+
   private
 
   def config_with(steps:, custom_steps: [])

--- a/test/setup_runner/command_factory_test.rb
+++ b/test/setup_runner/command_factory_test.rb
@@ -136,15 +136,6 @@ class CommandFactoryTest < ActiveSupport::TestCase
     refute_match(/Failed to create command/, io.string)
   end
 
-  test "tolerates config objects without a github_packages accessor" do
-    duck = Struct.new(:steps, :custom_steps).new(%w[env], [])
-    factory = Discharger::SetupRunner::CommandFactory.new(duck, Dir.pwd, Logger.new(StringIO.new))
-
-    commands = factory.create_all_commands
-
-    assert_equal 1, commands.size
-  end
-
   private
 
   def config_with(steps:, custom_steps: [])

--- a/test/setup_runner/commands/github_packages_command_test.rb
+++ b/test/setup_runner/commands/github_packages_command_test.rb
@@ -8,6 +8,7 @@ require "socket"
 
 class GithubPackagesCommandTest < ActiveSupport::TestCase
   include SetupRunnerTestHelper
+  include Capture3Stubbing
 
   SOURCE = "https://rubygems.pkg.github.com/example"
 
@@ -203,23 +204,6 @@ class GithubPackagesCommandTest < ActiveSupport::TestCase
   end
 
   private
-
-  # Captures the argv Open3.capture3 is called with so the credential write
-  # can be asserted without shelling out to a real bundler.
-  def stub_capture3(success:, stderr: "")
-    calls = []
-    original = Open3.method(:capture3)
-    status = Object.new
-    status.define_singleton_method(:success?) { success }
-    Open3.define_singleton_method(:capture3) do |*args|
-      calls << args
-      ["", stderr, status]
-    end
-    yield
-    calls
-  ensure
-    Open3.define_singleton_method(:capture3, original)
-  end
 
   # A command with real credential probing against the given source;
   # everything before the probe is stubbed to succeed.

--- a/test/setup_runner/commands/github_packages_command_test.rb
+++ b/test/setup_runner/commands/github_packages_command_test.rb
@@ -167,6 +167,25 @@ class GithubPackagesCommandTest < ActiveSupport::TestCase
     refute_match(/read:packages/, io.string)
   end
 
+  test "unscheduled_warning names the source when nothing schedules the command" do
+    message = Discharger::SetupRunner::Commands::GithubPackagesCommand.unscheduled_warning(@config)
+
+    assert_match(/missing from steps/, message)
+    assert_includes message, SOURCE
+  end
+
+  test "unscheduled_warning returns nil without a github_packages accessor" do
+    duck = Struct.new(:steps, :custom_steps).new(%w[env], [])
+
+    assert_nil Discharger::SetupRunner::Commands::GithubPackagesCommand.unscheduled_warning(duck)
+  end
+
+  test "unscheduled_warning returns nil when a custom step references the source" do
+    @config.custom_steps = [{"description" => "creds", "command" => "bundle config set --local #{SOURCE} user:token"}]
+
+    assert_nil Discharger::SetupRunner::Commands::GithubPackagesCommand.unscheduled_warning(@config)
+  end
+
   test "command is registered as github_packages" do
     require "discharger/setup_runner/command_registry"
     assert_equal Discharger::SetupRunner::Commands::GithubPackagesCommand,

--- a/test/setup_runner/commands/github_packages_command_test.rb
+++ b/test/setup_runner/commands/github_packages_command_test.rb
@@ -187,6 +187,32 @@ class GithubPackagesCommandTest < ActiveSupport::TestCase
     assert_nil Discharger::SetupRunner::Commands::GithubPackagesCommand.unscheduled_warning(@config)
   end
 
+  test "unscheduled_warning ignores source references in steps whose condition is false" do
+    @config.custom_steps = [{
+      "description" => "creds",
+      "command" => "bundle config set --local #{SOURCE} user:token",
+      "condition" => "ENV['DISCHARGER_TEST_CREDS'] == 'true'"
+    }]
+
+    message = Discharger::SetupRunner::Commands::GithubPackagesCommand.unscheduled_warning(@config)
+
+    refute_nil message, "a step skipped by its condition stores nothing this run"
+    assert_match(/missing from steps/, message)
+  end
+
+  test "unscheduled_warning stays quiet when the referencing step's condition is true" do
+    ENV["DISCHARGER_TEST_CREDS"] = "true"
+    @config.custom_steps = [{
+      "description" => "creds",
+      "command" => "bundle config set --local #{SOURCE} user:token",
+      "condition" => "ENV['DISCHARGER_TEST_CREDS'] == 'true'"
+    }]
+
+    assert_nil Discharger::SetupRunner::Commands::GithubPackagesCommand.unscheduled_warning(@config)
+  ensure
+    ENV.delete("DISCHARGER_TEST_CREDS")
+  end
+
   test "command is registered as github_packages" do
     require "discharger/setup_runner/command_registry"
     assert_equal Discharger::SetupRunner::Commands::GithubPackagesCommand,

--- a/test/setup_runner/integration_test.rb
+++ b/test/setup_runner/integration_test.rb
@@ -78,6 +78,62 @@ class SetupRunnerIntegrationTest < ActiveSupport::TestCase
         - env
     YAML
 
+    # Swap in a no-op subclass so the test never shells out to gh or the
+    # network; the real command would probe the source with live credentials.
+    registry = Discharger::SetupRunner::CommandRegistry
+    original = registry.get("github_packages")
+    noop = Class.new(original) do
+      def execute
+      end
+    end
+    registry.register("github_packages", noop)
+
+    io = StringIO.new
+    capture_output do
+      Discharger::SetupRunner.run("setup.yml", Logger.new(io))
+    end
+
+    refute_match(/missing from steps/, io.string)
+  ensure
+    registry.register("github_packages", original) if original
+  end
+
+  test "stays quiet when github_packages is scheduled programmatically" do
+    create_file("setup.yml", <<~YAML)
+      app_name: TestApp
+      github_packages:
+        source: "https://rubygems.pkg.github.com/example"
+      steps:
+        - env
+    YAML
+
+    noop = Class.new(Discharger::SetupRunner::Commands::GithubPackagesCommand) do
+      def execute
+      end
+    end
+
+    io = StringIO.new
+    capture_output do
+      Discharger::SetupRunner.run("setup.yml", Logger.new(io)) do |runner|
+        runner.add_command(noop.new(runner.config, Dir.pwd, runner.logger))
+      end
+    end
+
+    refute_match(/missing from steps/, io.string)
+  end
+
+  test "stays quiet when a custom step references the source" do
+    create_file("setup.yml", <<~YAML)
+      app_name: TestApp
+      github_packages:
+        source: "https://rubygems.pkg.github.com/example"
+      steps:
+        - env
+      custom_steps:
+        - description: "Store credentials"
+          command: "echo https://rubygems.pkg.github.com/example >/dev/null"
+    YAML
+
     io = StringIO.new
     capture_output do
       Discharger::SetupRunner.run("setup.yml", Logger.new(io))

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -299,72 +299,54 @@ class DischargerReleaseCommandSequenceTest < Minitest::Test
 end
 
 class DischargerPrAlreadyMergedTest < Minitest::Test
-  FakeStatus = Struct.new(:ok) do
-    def success? = ok
-  end
+  include Capture3Stubbing
 
   def setup
     @task = Discharger::Task.new
-    @original_capture3 = Open3.method(:capture3)
-  end
-
-  def teardown
-    Open3.define_singleton_method(:capture3, @original_capture3)
-  end
-
-  def stub_capture3(stdout, stderr, success)
-    status = FakeStatus.new(success)
-    Open3.define_singleton_method(:capture3) { |*_args| [stdout, stderr, status] }
   end
 
   def test_returns_true_when_pr_is_merged
-    stub_capture3("MERGED\n", "", true)
-    assert @task.pr_already_merged?("stage")
+    stub_capture3(stdout: "MERGED\n") do
+      assert @task.pr_already_merged?("stage")
+    end
   end
 
   def test_returns_false_when_pr_is_open
-    stub_capture3("OPEN\n", "", true)
-    refute @task.pr_already_merged?("stage")
+    stub_capture3(stdout: "OPEN\n") do
+      refute @task.pr_already_merged?("stage")
+    end
   end
 
   def test_returns_false_on_command_failure
-    stub_capture3("", "error", false)
-    refute @task.pr_already_merged?("stage")
+    stub_capture3(stderr: "error", success: false) do
+      refute @task.pr_already_merged?("stage")
+    end
   end
 end
 
 class DischargerExistingPrNumberTest < Minitest::Test
-  FakeStatus = Struct.new(:ok) do
-    def success? = ok
-  end
+  include Capture3Stubbing
 
   def setup
     @task = Discharger::Task.new
-    @original_capture3 = Open3.method(:capture3)
-  end
-
-  def teardown
-    Open3.define_singleton_method(:capture3, @original_capture3)
-  end
-
-  def stub_capture3(stdout, stderr, success)
-    status = FakeStatus.new(success)
-    Open3.define_singleton_method(:capture3) { |*_args| [stdout, stderr, status] }
   end
 
   def test_returns_pr_number_when_pr_exists
-    stub_capture3("42\n", "", true)
-    assert_equal "42", @task.existing_pr_number("main", "develop")
+    stub_capture3(stdout: "42\n") do
+      assert_equal "42", @task.existing_pr_number("main", "develop")
+    end
   end
 
   def test_returns_nil_when_no_pr_exists
-    stub_capture3("", "", true)
-    assert_nil @task.existing_pr_number("main", "develop")
+    stub_capture3 do
+      assert_nil @task.existing_pr_number("main", "develop")
+    end
   end
 
   def test_returns_nil_on_command_failure
-    stub_capture3("", "error", false)
-    assert_nil @task.existing_pr_number("main", "develop")
+    stub_capture3(stderr: "error", success: false) do
+      assert_nil @task.existing_pr_number("main", "develop")
+    end
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,3 +19,24 @@ require "discharger"
 require "discharger/task"
 
 require "debug"
+require "open3"
+
+# Swaps Open3.capture3 for the duration of a block, restoring the original
+# even when the block raises. Returns the argv arrays capture3 was called
+# with, so callers can assert on the executed command.
+module Capture3Stubbing
+  def stub_capture3(stdout: "", stderr: "", success: true)
+    calls = []
+    original = Open3.method(:capture3)
+    status = Object.new
+    status.define_singleton_method(:success?) { success }
+    Open3.define_singleton_method(:capture3) do |*args|
+      calls << args
+      [stdout, stderr, status]
+    end
+    yield
+    calls
+  ensure
+    Open3.define_singleton_method(:capture3, original)
+  end
+end


### PR DESCRIPTION
Stacked on #237. Addresses the remaining #233 review findings.

**Warning moved from the factory to a run-time hook.** `CommandFactory` no longer hardcodes github_packages knowledge; instead, command classes may opt in by defining `.unscheduled_warning(config)`, and the Runner checks each opted-in registry class after the customization block, warning only when no instance of that class made it into the command list. This fixes the false warning when the command is injected through the public `Runner#add_command`/`insert_command_*` APIs, and keeps the factory command-agnostic. The check is guarded with `respond_to?(:github_packages)`, so duck-typed configs passed to the public Runner API no longer raise (`GithubPackagesCommand#source` itself is untouched — the review's verify pass refuted that half of the finding). The message text is unchanged, so #240's integration test and existing assertions stay green, and because the hook runs on the Runner's always-defaulted logger, the warning reaches stdout in production independently of #240's fix.

**Custom-steps heuristic.** The warning also stays quiet when any custom step's command string references the configured source, on the assumption that such a step handles credentials itself (e.g. `bundle config set --local <source> ...`). This is a heuristic: a credential-storing script that doesn't mention the source URL will still warn.

**Test no longer shells out.** The "stays quiet when scheduled" integration test previously executed `GithubPackagesCommand` for real — live `gh` calls, the developer's actual token written to the temp `.bundle/config` and transmitted in an HTTPS probe, and a potential interactive `gh auth login` hang. It now swaps in a no-op subclass via the registry (restored in `ensure`).

**One shared `Open3.capture3` stub.** The three hand-rolled variants (two in `task_test.rb`, one in the github_packages test) are consolidated into a block-scoped `Capture3Stubbing#stub_capture3` in `test_helper.rb` that records argv and always restores the original.